### PR TITLE
Locked bcrypto version to 5.2.0 to avoid compilation errors on macos

### DIFF
--- a/package.json
+++ b/package.json
@@ -76,5 +76,8 @@
     "react-dom": "^16.13.1",
     "tsdx": "^0.13.2",
     "typescript": "4.0.2"
+  },
+  "resolutions": {
+    "bcrypto": "5.2.0"
   }
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -8754,12 +8754,12 @@ bcrypt-pbkdf@^1.0.0:
   dependencies:
     tweetnacl "^0.14.3"
 
-bcrypto@5.1.0:
-  version "5.1.0"
-  resolved "https://registry.yarnpkg.com/bcrypto/-/bcrypto-5.1.0.tgz#1ca3d0b1bd1ffe6bb18cfcf2a7d7fc19423b68e6"
-  integrity sha512-WEs5g7WHdEdLLcsvhE7Z1AXv0G+hb+bJhSUYM7samFNrH051XhcFVWxAbAZDmIU1HWjpjhmQ+HqBar7UC/qrzQ==
+bcrypto@5.1.0, bcrypto@5.2.0:
+  version "5.2.0"
+  resolved "https://registry.yarnpkg.com/bcrypto/-/bcrypto-5.2.0.tgz#7cc944d2cc2b7beeff04c74f8611a001612a981d"
+  integrity sha512-yy+kDrUG6aXP7NIYq7kKIwlrXtx/51488IGfuqhyM6FYF8zNI1mPRwvAPvQ1RfE5e7WW7fVdZt4yHlmN4HJ4Hg==
   dependencies:
-    bufio "~1.0.6"
+    bufio "~1.0.7"
     loady "~0.0.1"
 
 bech32@1.1.4, bech32@^1.1.2:
@@ -9255,7 +9255,7 @@ bufferutil@^4.0.1:
   dependencies:
     node-gyp-build "~3.7.0"
 
-bufio@~1.0.6:
+bufio@~1.0.7:
   version "1.0.7"
   resolved "https://registry.yarnpkg.com/bufio/-/bufio-1.0.7.tgz#b7f63a1369a0829ed64cc14edf0573b3e382a33e"
   integrity sha512-bd1dDQhiC+bEbEfg56IdBv7faWa6OipMs/AFFFvtFnB3wAYjlwQpQRZ0pm6ZkgtfL0pILRXhKxOiQj6UzoMR7A==


### PR DESCRIPTION
JayWelsh and I both ran into issues initially building the repo on macos. 

This overrides the `5.1.0` version pulled in through our dependencies.

This may not be an ideal fix, but it's here at least for reference.