### PR TITLE
Update guide to include typescript compile

### DIFF
--- a/README.md
+++ b/README.md
@@ -121,17 +121,3 @@ yarn docker:start
 ```shell script
 yarn typecheck
 ```
-
-### Run backend without docker for debugging
-
-If you want to run the NodeJS backend service out of docker to be able to debug with your IDE:
-
-**Add environment variable** to tell hasura where to find the backend (may only work on MacOS)
-```shell script
-echo 'BACKEND_HOST=host.docker.internal:4000' >> .env
-```
-
-**Start the server**
-```shell script
-yarn backend:dev
-```

--- a/README.md
+++ b/README.md
@@ -10,11 +10,6 @@ If you're new to the MetaGame codebase, check out the following guides to learn 
 
 ## Development
 
-### Install Packages
-
-```shell script
-yarn
-```
 
 ### Bootstrap
 
@@ -22,6 +17,12 @@ Create your local .env file
 
 ```shell script
 cp .env.sample .env
+```
+
+### Install Packages
+
+```shell script
+yarn
 ```
 
 Initial TS Compilation For Monorepo Packages
@@ -119,4 +120,18 @@ yarn docker:start
 
 ```shell script
 yarn typecheck
+```
+
+### Run backend without docker for debugging
+
+If you want to run the NodeJS backend service out of docker to be able to debug with your IDE:
+
+**Add environment variable** to tell hasura where to find the backend (may only work on MacOS)
+```shell script
+echo 'BACKEND_HOST=host.docker.internal:4000' >> .env
+```
+
+**Start the server**
+```shell script
+yarn backend:dev
 ```

--- a/guides/BACKEND.md
+++ b/guides/BACKEND.md
@@ -78,6 +78,20 @@ curl -X POST http://localhost:4000/actions/migrateSourceCredAccounts
 
 Which populates it with testing data.
 
+### Run backend without docker for debugging
+
+If you want to run the NodeJS backend service out of docker to be able to debug with your IDE:
+
+**Add environment variable** to tell hasura where to find the backend (may only work on MacOS)
+```shell script
+echo 'BACKEND_HOST=host.docker.internal:4000' >> .env
+```
+
+**Start the server**
+```shell script
+yarn backend:dev
+```
+
 ### Configuring Hasura
 
 Before you can create a new table. You'll need to initialize hasura. The same commands are found in the tooling section of the `README.md`.

--- a/guides/BACKEND.md
+++ b/guides/BACKEND.md
@@ -19,6 +19,9 @@ cp .env.sample .env
 # Remove potential stale containers
 yarn docker:clean
 
+# Install node dependencies
+yarn
+
 # Build typescript apps
 yarn typecheck
 ```

--- a/guides/BACKEND.md
+++ b/guides/BACKEND.md
@@ -55,6 +55,18 @@ CONTAINER ID        IMAGE               COMMAND                  CREATED        
 38e3140ab632        postgres:12         "docker-entrypoint.s…"   51 minutes ago      Up 2 minutes        0.0.0.0:5432->5432/tcp   the-game_database_1
 ```
 
+You can also read the logs of the services by running `docker-compose logs -f $SERVICE` (replace $SERVICE by `backend` or `hasura`)
+
+```bash
+$ docker-compose logs -f backend
+
+...
+backend_1   | @metafam/backend: [1] [18:59:07] Generate ./src/lib/autogen/daohaus-sdk.ts [completed]
+backend_1   | @metafam/backend: [1] [18:59:07] Generate outputs [completed]
+backend_1   | @metafam/backend: [1]   ℹ Watching for changes...
+backend_1   | @metafam/backend: [0] Listening on port 4000
+```
+
 After which you can run:
 
 ```bash

--- a/guides/BACKEND.md
+++ b/guides/BACKEND.md
@@ -16,11 +16,11 @@ Before you can start the Docker containers, you must run the following.
 # Copy the example environment
 cp .env.sample .env
 
-# Add the BACKEND_HOST environment variable
-echo 'BACKEND_HOST=host.docker.internal:4000' >> .env
-
 # Remove potential stale containers
 yarn docker:clean
+
+# Build typescript apps
+yarn typecheck
 ```
 
 ### Starting the BackEnd


### PR DESCRIPTION
I cloned the repo to a fresh install to verify that everything was working out of the box, and here's my findings:

- The `BACKEND_HOST=host.docker.internal:4000` line is only needed when one wants to start the backend without docker. Not needed in most cases.

- Before we can run either the frontend or the backend, every apps must be compiled with typescript with `yarn typecheck`.
If we don't do that, the backend will appear running with `docker ps` but will not be started as the typescript watcher found errors in the code and won't start the node server.