### PR TITLE
MyMeta SEED Ticker

### DIFF
--- a/packages/web/components/PageHeader.tsx
+++ b/packages/web/components/PageHeader.tsx
@@ -2,6 +2,7 @@ import { Box, Button, Flex, Image, Stack } from '@metafam/ds';
 import MetaGameImage from 'assets/metagame.png';
 import { MetaLink } from 'components/Link';
 import { LoginButton } from 'components/LoginButton';
+import { Ticker } from 'components/Ticker';
 import React from 'react';
 
 const MenuItem: React.FC<React.ComponentProps<typeof MetaLink>> = ({
@@ -92,10 +93,12 @@ export const PageHeader: React.FC = () => {
       </Box>
 
       <Box
-        display={{ base: show ? 'flex' : 'none', md: 'block' }}
+        display={{ base: show ? 'block' : 'none', md: 'flex' }}
         justifyContent="center"
+        alignItems="center"
         width={{ base: 'full', md: 'auto' }}
       >
+        <Ticker />
         <LoginButton />
       </Box>
     </Flex>

--- a/packages/web/components/Ticker.tsx
+++ b/packages/web/components/Ticker.tsx
@@ -1,0 +1,29 @@
+import { Flex, Image, P } from '@metafam/ds';
+import MetaGameLogo from 'assets/logo.png';
+import fetch from 'node-fetch';
+import React, { useEffect, useState } from 'react';
+
+export const Ticker: React.FC = () => {
+  const [price, setPrice] = useState(0);
+
+  useEffect(() => {
+    fetch(
+      `https://api.coingecko.com/api/v3/simple/price?ids=metagame&vs_currencies=usd`,
+    )
+      .then((response) => response.json())
+      .then((data) => setPrice(data.metagame.usd));
+  }, [price, setPrice]);
+
+  return (
+    <Flex alignItems="center" margin="15px">
+      <Image
+        src={MetaGameLogo}
+        alt="MetaGameLogo"
+        objectFit="contain"
+        boxSize="2rem"
+        margin="0 15px 0 0"
+      />
+      <P>${price.toFixed(2)} SEEDS</P>
+    </Flex>
+  );
+};

--- a/packages/web/package.json
+++ b/packages/web/package.json
@@ -22,6 +22,7 @@
     "next": "latest",
     "next-images": "^1.4.1",
     "next-urql": "2.0.0",
+    "node-fetch": "^2.6.1",
     "react": "^16.13.1",
     "react-dom": "^16.13.1",
     "react-icons": "^3.11.0",


### PR DESCRIPTION
### Description

- Shows the price of SEEDs on the top header.

- Pulls data from CoinGecko.

- Adds `node-fetch` to mymeta. Which was already a child dependency.

### Screenshots

**Desktop**

![1](https://user-images.githubusercontent.com/68780068/102130765-3c35d000-3e1f-11eb-89ac-8fd37751b852.png)

**Mobile**

![2](https://user-images.githubusercontent.com/68780068/102130782-4526a180-3e1f-11eb-9c4a-81321a9ecb61.png)

