### PR TITLE
Add build workflow to CI so errors can be shown in GitHub instead of Vercel

### DIFF
--- a/.github/workflows/PR-CI.yml
+++ b/.github/workflows/PR-CI.yml
@@ -47,3 +47,38 @@ jobs:
         run: yarn test --ci --coverage
         env:
           CI: true
+
+  build:
+    name: Build
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Cancel Previous Runs
+        uses: styfle/cancel-workflow-action@0.4.0
+        with:
+          access_token: ${{ github.token }}
+      - uses: actions/checkout@v2
+      - uses: actions/setup-node@v1
+        with:
+          node-version: 12.x
+
+      - uses: actions/cache@v2
+        with:
+          path: '**/node_modules'
+          key: nodeModules-${{ runner.os }}-${{ hashFiles('**/yarn.lock') }}
+
+      - name: Install packages
+        run: yarn --frozen-lockfile
+        env:
+          CI: true
+
+      - name: Build Web
+        run: yarn web:build
+        env:
+          CI: true
+          NEXT_PUBLIC_GRAPHQL_URL: ${{ secrets.NEXT_PUBLIC_GRAPHQL_URL }}
+
+      - name: Build Backend
+        run: yarn backend:build
+        env:
+          CI: true


### PR DESCRIPTION
Should help contributors debug their builds easier