### PR TITLE
Feature/add timezone backend

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -31,6 +31,7 @@ out/
 .env.test.local
 .env.production.local
 
+lerna-debug.log*
 npm-debug.log*
 yarn-debug.log*
 yarn-error.log*

--- a/hasura/metadata/tables.yaml
+++ b/hasura/metadata/tables.yaml
@@ -148,6 +148,7 @@
       - scIdentityId
       - timezone
       - totalXp
+      - tz
       - username
       filter: {}
   - role: public
@@ -161,6 +162,7 @@
       - role
       - timezone
       - totalXp
+      - tz
       - username
       filter: {}
   update_permissions:
@@ -172,6 +174,7 @@
       - playerTypeId
       - role
       - timezone
+      - tz
       - username
       filter:
         id:

--- a/hasura/migrations/1605829703638_alter_table_public_Player_add_column_tz/down.sql
+++ b/hasura/migrations/1605829703638_alter_table_public_Player_add_column_tz/down.sql
@@ -1,0 +1,1 @@
+ALTER TABLE "public"."Player" DROP COLUMN "tz";

--- a/hasura/migrations/1605829703638_alter_table_public_Player_add_column_tz/up.sql
+++ b/hasura/migrations/1605829703638_alter_table_public_Player_add_column_tz/up.sql
@@ -1,0 +1,1 @@
+ALTER TABLE "public"."Player" ADD COLUMN "tz" text NULL;

--- a/packages/codegen/schema.graphql
+++ b/packages/codegen/schema.graphql
@@ -1992,6 +1992,7 @@ type Player {
   scIdentityId: String
   timezone: Int
   totalXp: numeric
+  tz: String
   updated_at: timestamptz
   username: String!
 }
@@ -2086,6 +2087,7 @@ input Player_bool_exp {
   scIdentityId: String_comparison_exp
   timezone: Int_comparison_exp
   totalXp: numeric_comparison_exp
+  tz: String_comparison_exp
   updated_at: timestamptz_comparison_exp
   username: String_comparison_exp
 }
@@ -2136,6 +2138,7 @@ input Player_insert_input {
   scIdentityId: String
   timezone: Int
   totalXp: numeric
+  tz: String
   updated_at: timestamptz
   username: String
 }
@@ -2151,6 +2154,7 @@ type Player_max_fields {
   scIdentityId: String
   timezone: Int
   totalXp: numeric
+  tz: String
   updated_at: timestamptz
   username: String
 }
@@ -2168,6 +2172,7 @@ input Player_max_order_by {
   scIdentityId: order_by
   timezone: order_by
   totalXp: order_by
+  tz: order_by
   updated_at: order_by
   username: order_by
 }
@@ -2183,6 +2188,7 @@ type Player_min_fields {
   scIdentityId: String
   timezone: Int
   totalXp: numeric
+  tz: String
   updated_at: timestamptz
   username: String
 }
@@ -2200,6 +2206,7 @@ input Player_min_order_by {
   scIdentityId: order_by
   timezone: order_by
   totalXp: order_by
+  tz: order_by
   updated_at: order_by
   username: order_by
 }
@@ -2251,6 +2258,7 @@ input Player_order_by {
   scIdentityId: order_by
   timezone: order_by
   totalXp: order_by
+  tz: order_by
   updated_at: order_by
   username: order_by
 }
@@ -2474,6 +2482,9 @@ enum Player_select_column {
   totalXp
 
   """column name"""
+  tz
+
+  """column name"""
   updated_at
 
   """column name"""
@@ -2495,6 +2506,7 @@ input Player_set_input {
   scIdentityId: String
   timezone: Int
   totalXp: numeric
+  tz: String
   updated_at: timestamptz
   username: String
 }
@@ -2783,6 +2795,9 @@ enum Player_update_column {
 
   """column name"""
   totalXp
+
+  """column name"""
+  tz
 
   """column name"""
   updated_at


### PR DESCRIPTION
I noticed an existing timezone (int) field already in the player table. Didn't want to delete it until I know it's not being used. I'm storing IANA timezones as they're more precise, and an hourly differential can be computed accurately from that.

Seems we should remove the timezone field if it's not being used.