### PR TITLE
Add step to remove duplicate players in migrateSourceCredAccounts

### DIFF
--- a/packages/backend/src/handlers/graphql/mutations.ts
+++ b/packages/backend/src/handlers/graphql/mutations.ts
@@ -39,6 +39,18 @@ export const UpsertPlayer = gql`
     }
   }
 `;
+export const DeleteDuplicatePlayers = gql`
+  mutation DeleteDuplicatePlayers($scIds: [String!] = "") {
+    delete_player_account(
+      where: { Player: { sc_identity_id: { _in: $scIds } } }
+    ) {
+      affected_rows
+    }
+    delete_player(where: { sc_identity_id: { _in: $scIds } }) {
+      affected_rows
+    }
+  }
+`;
 
 export const UpdatePlayer = gql`
   mutation UpdatePlayer(
@@ -71,7 +83,6 @@ export const UpdatePlayer = gql`
       _set: {
         ethereum_address: $ethAddress
         sc_identity_id: $identityId
-        username: $username
         rank: $rank
         total_xp: $totalXp
       }


### PR DESCRIPTION
Some accounts in SourceCred get merged after they had already been added in the database (e.g. merging
a discord and discourse identity) which causes conflicts in the database when we try to set an
ETH address for the new merged account that conflicts with the old unmerged account.