### PR TITLE
Codegen wasn't completely removed

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -45,7 +45,6 @@ services:
       - ./packages/@types:/usr/src/app/packages/@types
       - ./packages/backend:/usr/src/app/packages/backend
       - ./packages/utils:/usr/src/app/packages/utils
-      - ./packages/codegen:/usr/src/app/packages/codegen
       - ./package.json:/usr/src/app/package.json
       - ./tsconfig.base.json:/usr/src/app/tsconfig.base.json
       - ./yarn.lock:/usr/src/app/yarn.lock

--- a/docker/backend/Dockerfile
+++ b/docker/backend/Dockerfile
@@ -10,10 +10,10 @@ ENV HASURA_GRAPHQL_ADMIN_SECRET metagame_secret
 COPY package.json .
 COPY lerna.json .
 COPY yarn.lock .
+COPY schema.graphql .
 COPY tsconfig.base.json .
 COPY packages/backend/*.json ./packages/backend/
 COPY packages/utils/*.json ./packages/utils/
-COPY packages/codegen/*.json ./packages/codegen/
 
 RUN yarn install --pure-lockfile
 
@@ -24,7 +24,6 @@ FROM base as build
 COPY packages/backend ./packages/backend/
 COPY packages/utils ./packages/utils/
 COPY packages/@types ./packages/@types/
-COPY packages/codegen ./packages/codegen/
 
 # Build
 RUN yarn backend:build

--- a/package.json
+++ b/package.json
@@ -29,7 +29,6 @@
     "precommit": "lerna run --concurrency 1 --stream precommit",
     "prepush": "yarn typecheck",
     "backend": "yarn --cwd packages/backend/",
-    "codegen": "yarn --cwd packages/codegen/",
     "utils": "yarn --cwd packages/utils/",
     "web": "yarn --cwd packages/web/",
     "ds": "yarn --cwd packages/design-system/"


### PR DESCRIPTION
#316 removes the `codegen` task, but there were still references remaining that prevented building a clean docker distribution.