### PR TITLE
Fixed an issue doesn't show save map title in change popover modal

### DIFF
--- a/packages/metamaps/components/map/Map.popover.tsx
+++ b/packages/metamaps/components/map/Map.popover.tsx
@@ -41,7 +41,7 @@ export const MapPopoverComponent: FC<MapPopoverProps> = ({
   }, [dispatch, state]);
 
   async function updateMapName() {
-    await executeMutation({ id, name });
+    await executeMutation({ id, name: nameInput });
   }
 
   return (

--- a/packages/metamaps/pages/[author_address]/map/[id].tsx
+++ b/packages/metamaps/pages/[author_address]/map/[id].tsx
@@ -78,6 +78,8 @@ export const MapPageComponent: FC<MapPageProps> = ({ dispatch }) => {
     data: items,
   });
 
+  dispatch({ type: 'POPOVER_NAME_INPUT', value: data?.Map_by_pk.name });
+
   return (
     <AppContainer>
       <Map />


### PR DESCRIPTION
Fixes  #358
Fixed an issue doesn't show save map title in change popover modal.
And then, updated to show the default existing map title when open the popup modal