### PR TITLE
Adding comments to silence eslint

### DIFF
--- a/packages/@types/3box/index.d.ts
+++ b/packages/@types/3box/index.d.ts
@@ -64,5 +64,5 @@ declare module '3box' {
       username: string;
     };
   }
-  export async function openBox(ethAddress: string, web3: any): Promise<Box>;
+  export async function openBox(ethAddress: string, web3: unknown): Promise<Box>;
 }

--- a/packages/backend/src/handlers/actions/migrateSourceCredAccounts/handler.ts
+++ b/packages/backend/src/handlers/actions/migrateSourceCredAccounts/handler.ts
@@ -40,6 +40,7 @@ const parseMergedIdentityId = (alias: SCAlias) => {
     }
     return null;
   } catch (e) {
+    // eslint-disable-next-line no-console
     console.log('Unable to parse merged identity: ', {
       error: e.message,
       alias,
@@ -64,6 +65,7 @@ const parseAlias = (alias: SCAlias) => {
       identifier,
     };
   } catch (e) {
+    // eslint-disable-next-line no-console
     console.log('Unable to parse alias: ', { error: e.message, alias });
     return null;
   }
@@ -163,6 +165,7 @@ export const migrateSourceCredAccounts = async (
                 on_conflict: accountOnConflict,
               });
             } catch (accErr) {
+              // eslint-disable-next-line no-console
               console.log(
                 'Error updating accounts for Player',
                 playerId,
@@ -172,6 +175,7 @@ export const migrateSourceCredAccounts = async (
             }
           }
         } catch (e) {
+          // eslint-disable-next-line no-console
           console.warn('ERR! failed to update player', e);
           return player;
         }
@@ -207,6 +211,7 @@ export const migrateSourceCredAccounts = async (
       numInserted: usersToInsert.length,
     });
   } catch (e) {
+    // eslint-disable-next-line no-console
     console.warn('Error migrating players/accounts', e.message);
     res.sendStatus(500);
   }

--- a/packages/backend/src/handlers/actions/updateBoxProfile/updateVerifiedAccounts.ts
+++ b/packages/backend/src/handlers/actions/updateBoxProfile/updateVerifiedAccounts.ts
@@ -31,6 +31,7 @@ export async function updateVerifiedAccounts(
     if (result.insert_player_account?.affected_rows) {
       updatedProfiles.push('github');
     } else {
+      // eslint-disable-next-line no-console
       console.warn(
         `Unable to insert Github user ${verifiedAccounts.github.username} for playerId ${playerId}`,
       );
@@ -50,6 +51,7 @@ export async function updateVerifiedAccounts(
     if (result.insert_player_account?.affected_rows) {
       updatedProfiles.push('twitter');
     } else {
+      // eslint-disable-next-line no-console
       console.warn(
         `Unable to insert Twitter user ${verifiedAccounts.twitter.username} for playerId ${playerId}`,
       );

--- a/packages/backend/src/handlers/triggers/types.ts
+++ b/packages/backend/src/handlers/triggers/types.ts
@@ -1,4 +1,4 @@
-export interface TriggerPayload<T = any> {
+export interface TriggerPayload<T = unknown> {
   event: {
     session_variables: { [x: string]: string };
     op: 'INSERT' | 'UPDATE' | 'DELETE' | 'MANUAL';

--- a/packages/backend/src/index.ts
+++ b/packages/backend/src/index.ts
@@ -14,5 +14,6 @@ app.use(router);
 app.use(errorMiddleware);
 
 app.listen(CONFIG.port, () => {
+  // eslint-disable-next-line no-console
   console.log(`Listening on port ${CONFIG.port}`);
 });

--- a/packages/metamaps/redux/ThreeBox.tsx
+++ b/packages/metamaps/redux/ThreeBox.tsx
@@ -1,9 +1,9 @@
 import Box from '3box';
 
-declare const window: any;
+declare const window: Record<string, unknown>;
 
 export async function Load3BoxUrl(account: string, url: string) {
-    return async function(dispatch: any) {
+    return async (dispatch: (unknown) => void): Promise<void> => {
         try {
             dispatch({ type: 'LOADING', value: true });
 
@@ -15,15 +15,15 @@ export async function Load3BoxUrl(account: string, url: string) {
             dispatch({ type: 'LOADED_3BOX_URL', data: data ? JSON.parse(data) : [] });
             dispatch({ type: 'LOADING', value: false });
         } catch (error) {
-            console.error(error);
+            console.error(error); // eslint-disable-line no-console
             dispatch({ type: 'LOADED_3BOX_URL', data: [] });
             dispatch({ type: 'LOADING', value: false });
         }
     }
 }
 
-export async function Save3BoxUrl(account: string, url: string, data: any) {
-    return async function(dispatch: any) {
+export async function Save3BoxUrl(account: string, url: string, data: unknown) {
+    return async (dispatch: (unknown) => void): Promise<void> => {
         try {
             const box = await Box.openBox(account, window.ethereum);
             await box.syncDone;
@@ -32,7 +32,7 @@ export async function Save3BoxUrl(account: string, url: string, data: any) {
 
             dispatch({ type: 'SAVED_3BOX_URL' });
         } catch (error) {
-            console.error(error);
+            console.error(error); // eslint-disable-line no-console
             dispatch({ type: 'SAVED_3BOX_URL_ERROR' });
         }
     }

--- a/packages/utils/src/did/index.ts
+++ b/packages/utils/src/did/index.ts
@@ -53,6 +53,7 @@ export async function verifyToken(
     }
     return claim;
   } catch (e) {
+     // eslint-disable-next-line no-console
     console.error('Token verification failed', e);
     return null;
   }

--- a/packages/web/contexts/Web3Context.tsx
+++ b/packages/web/contexts/Web3Context.tsx
@@ -130,7 +130,7 @@ export const Web3ContextProvider: React.FC<Web3ContextProviderOptions> = ({
       setIsConnected(true);
       if (resetUrqlClient) resetUrqlClient();
     } catch (error) {
-      console.log(error);
+      console.log(error); // eslint-disable-line no-console
       setIsConnecting(false);
       disconnect();
     }


### PR DESCRIPTION
The bottom of each pull request has a bunch of linter noise, primarily for the use of the `console`.

This request adds a bunch of comments to silence eslint for those uses as well as a couple conversions from `any` to `unknown`.