### PR TITLE
Fixed webhook auth for public requests

### DIFF
--- a/packages/backend/src/handlers/auth-webhook/handler.ts
+++ b/packages/backend/src/handlers/auth-webhook/handler.ts
@@ -11,7 +11,7 @@ const unauthorizedVariables = {
 function getHeaderToken(req: Request): string | null {
   const authHeader = req.headers.authorization;
   if (!authHeader) return null;
-  if (authHeader.substring(0, 7) !== 'Bearer')
+  if (authHeader.substring(0, 6) !== 'Bearer')
     throw new Error('invalid token type');
 
   const token = authHeader.replace('Bearer', '').trim();

--- a/packages/backend/src/handlers/auth-webhook/handler.ts
+++ b/packages/backend/src/handlers/auth-webhook/handler.ts
@@ -11,10 +11,10 @@ const unauthorizedVariables = {
 function getHeaderToken(req: Request): string | null {
   const authHeader = req.headers.authorization;
   if (!authHeader) return null;
-  if (authHeader.substring(0, 7) !== 'Bearer ')
+  if (authHeader.substring(0, 7) !== 'Bearer')
     throw new Error('invalid token type');
 
-  const token = authHeader.replace('Bearer ', '');
+  const token = authHeader.replace('Bearer', '').trim();
   if (token.length === 0) return null;
   return token;
 }


### PR DESCRIPTION
Found this bug while implementing the discord oauth handler. I believe it hasn't been an issue before because any graphql requests are happening at compile-time currently.