### PR TITLE
[MyMeta] Correcting invalid username error

### DIFF
--- a/packages/web/components/Setup/SetupUsername.tsx
+++ b/packages/web/components/Setup/SetupUsername.tsx
@@ -36,7 +36,7 @@ export const SetupUsername: React.FC<SetupUsernameProps> = ({
         errorDetail = 'This username is already taken 😢';
       } else if (error.message.includes('username_is_valid')) {
         errorDetail =
-          'A username can only contain letters, numbers, and dashes.';
+          'A username can only contain lowercase letters, numbers, and dashes.';
       }
       toast({
         title: 'Error',


### PR DESCRIPTION
Usernames are invalid if they contain capital letters, but the message doesn't specify that.

Paired with: @jsusim.