### PR TITLE
[MyMeta] Allow username to be completely removed

### DIFF
--- a/packages/web/components/Setup/SetupAvailability.tsx
+++ b/packages/web/components/Setup/SetupAvailability.tsx
@@ -65,7 +65,7 @@ export const SetupAvailability: React.FC<SetupAvailabilityProps> = ({
   return (
     <FlexContainer>
       <MetaHeading mb={5} textAlign="center">
-        Availability
+        Avail&#xAD;ability
       </MetaHeading>
       <Text mb={10}>
         What is your weekly availability for any kind of freelance work?

--- a/packages/web/components/Setup/SetupSkills.tsx
+++ b/packages/web/components/Setup/SetupSkills.tsx
@@ -83,7 +83,7 @@ export const SetupSkills: React.FC<SetupSkillsProps> = ({
   return (
     <FlexContainer>
       <MetaHeading mb={10} mt={-64} textAlign="center">
-        What are your superpowers?
+        What are your super&#xAD;powers?
       </MetaHeading>
       <FlexContainer w="100%" align="stretch" maxW="50rem">
         <SelectSearch

--- a/packages/web/components/Setup/SetupUsername.tsx
+++ b/packages/web/components/Setup/SetupUsername.tsx
@@ -6,8 +6,10 @@ import { useUser } from 'lib/hooks';
 import React, { useState } from 'react';
 
 export type SetupUsernameProps = {
-  username: string;
-  setUsername: React.Dispatch<React.SetStateAction<string>>;
+  username: string | undefined;
+  setUsername: (
+    React.Dispatch<React.SetStateAction<string | undefined>>
+  );
 };
 
 export const SetupUsername: React.FC<SetupUsernameProps> = ({
@@ -18,7 +20,9 @@ export const SetupUsername: React.FC<SetupUsernameProps> = ({
   const { user } = useUser({ redirectTo: '/' });
   const toast = useToast();
 
-  const [updateUsernameRes, updateUsername] = useUpdatePlayerUsernameMutation();
+  const [updateUsernameRes, updateUsername] = (
+    useUpdatePlayerUsernameMutation()
+  );
   const [loading, setLoading] = useState(false);
 
   const handleNextPress = async () => {
@@ -27,7 +31,7 @@ export const SetupUsername: React.FC<SetupUsernameProps> = ({
     setLoading(true);
     const { error } = await updateUsername({
       playerId: user.id,
-      username,
+      username: username ?? '',
     });
 
     if (error) {
@@ -63,6 +67,7 @@ export const SetupUsername: React.FC<SetupUsernameProps> = ({
         onChange={(e: React.ChangeEvent<HTMLInputElement>) =>
           setUsername(e.target.value)
         }
+        w="auto"
       />
 
       <MetaButton

--- a/packages/web/pages/profile/setup/username.tsx
+++ b/packages/web/pages/profile/setup/username.tsx
@@ -16,7 +16,9 @@ export const getStaticProps = async () => {
 export type DefaultSetupProps = InferGetStaticPropsType<typeof getStaticProps>;
 
 const UsernameSetup: React.FC<DefaultSetupProps> = () => {
-  const [username, setUsername] = useState<string>('');
+  const [username, setUsername] = (
+    useState<string | undefined>(undefined)
+  );
   const { address } = useWeb3();
   const { user } = useUser({ redirectTo: '/' });
 
@@ -25,7 +27,7 @@ const UsernameSetup: React.FC<DefaultSetupProps> = () => {
     if (
       player.username &&
       player.username.toLowerCase() !== address?.toLowerCase() &&
-      !username
+      username === undefined
     ) {
       setUsername(player.username);
     }


### PR DESCRIPTION
The current code replaces a users name with the name from the backend if the username input is completely cleared.

These changes allow it to be removed and add soft hyphens in a couple places to allow cleaner word splitting on mobile.

Paired with: @jsusim.