### PR TITLE
computing patron rank in react

### DIFF
--- a/packages/backend/src/lib/rankHelpers.ts
+++ b/packages/backend/src/lib/rankHelpers.ts
@@ -1,3 +1,5 @@
+import { computeRank as computeRankUtil, computeRankCap } from '@metafam/utils';
+
 import { PlayerRank_Enum } from './autogen/hasura-sdk';
 
 export const RANKS = [
@@ -6,27 +8,18 @@ export const RANKS = [
   PlayerRank_Enum.Gold,
   PlayerRank_Enum.Silver,
   PlayerRank_Enum.Bronze,
-]
+];
 
 export const PLAYERS_PER_RANK = [7, 7, 7, 14, 21];
 
-// A summation of PLAYERS_PER_RANK.
-// This is the first index for which players will NOT be ranked, e.g.
-// the 56th player will be Bronze, and the 57th player will not be ranked.
-export const RANKED_CAP: number = PLAYERS_PER_RANK.reduce((sum, rankCount) => {
-  return sum + rankCount;
-}, 0);
+export const RANKED_CAP = computeRankCap(PLAYERS_PER_RANK);
 
 // Computes the rank for the given index. This would be the index corresponding
 // to all players ordered by total_xp DESC.
 export function computeRank(totalRankIndex: number): PlayerRank_Enum | null {
-  if (totalRankIndex >= RANKED_CAP) return null;
-  let indexSum = 0;
-  for (let i = 0; i < PLAYERS_PER_RANK.length; i++) {
-    indexSum += PLAYERS_PER_RANK[i];
-    if (totalRankIndex < indexSum) {
-      return RANKS[i];
-    }
-  }
-  return null;
+  return computeRankUtil(
+    totalRankIndex,
+    PLAYERS_PER_RANK,
+    RANKS,
+  ) as PlayerRank_Enum | null;
 }

--- a/packages/utils/src/index.ts
+++ b/packages/utils/src/index.ts
@@ -4,3 +4,4 @@ export * as did from './did';
 export * as DiscordUtil from './discordHelpers';
 export * as numbers from './numbers';
 export * from './promiseHelpers';
+export * from './rankHelpers';

--- a/packages/utils/src/rankHelpers.ts
+++ b/packages/utils/src/rankHelpers.ts
@@ -1,12 +1,12 @@
 // A summation of usersPerRank
 // This is the first index for which users will NOT be ranked
-const computeRankCap = (usersPerRank: Array<number>) =>
+export const computeRankCap = (usersPerRank: Array<number>) =>
   usersPerRank.reduce((sum, rankCount) => {
     return sum + rankCount;
   }, 0);
 
 // Computes the rank for the given index. This would be the index corresponding
-// to all players ordered by total_xp DESC.
+// to all users ordered by total_xp DESC.
 export function computeRank(
   rankIndex: number,
   usersPerRank: Array<number>,

--- a/packages/web/components/Patron/PatronTile.tsx
+++ b/packages/web/components/Patron/PatronTile.tsx
@@ -17,7 +17,11 @@ import { PlayerContacts } from 'components/Player/PlayerContacts';
 import { PlayerTileMemberships } from 'components/Player/PlayerTileMemberships';
 import { SkillsTags } from 'components/Skills';
 import { utils } from 'ethers';
-import { PlayerFragmentFragment, Skill } from 'graphql/autogen/types';
+import {
+  PlayerFragmentFragment,
+  PlayerRank_Enum,
+  Skill,
+} from 'graphql/autogen/types';
 import { Patron } from 'graphql/types';
 import React from 'react';
 import {
@@ -27,6 +31,16 @@ import {
 } from 'utils/playerHelpers';
 import { computeRank } from 'utils/rankHelpers';
 
+const PATRON_RANKS = [
+  PlayerRank_Enum.Diamond,
+  PlayerRank_Enum.Platinum,
+  PlayerRank_Enum.Gold,
+  PlayerRank_Enum.Silver,
+  PlayerRank_Enum.Bronze,
+];
+
+const PATRONS_PER_RANK = [7, 7, 7, 14, 21];
+
 type Props = {
   patron: Patron;
   index: number;
@@ -34,7 +48,7 @@ type Props = {
 
 export const PatronTile: React.FC<Props> = ({ index, patron }) => {
   const player = patron as PlayerFragmentFragment;
-  const patronRank = computeRank(index);
+  const patronRank = computeRank(index, PATRONS_PER_RANK, PATRON_RANKS);
   return (
     <MetaTile>
       <Box

--- a/packages/web/components/Patron/PatronTile.tsx
+++ b/packages/web/components/Patron/PatronTile.tsx
@@ -25,13 +25,16 @@ import {
   getPlayerImage,
   getPlayerName,
 } from 'utils/playerHelpers';
+import { computeRank } from 'utils/rankHelpers';
 
 type Props = {
   patron: Patron;
+  index: number;
 };
 
-export const PatronTile: React.FC<Props> = ({ patron }) => {
+export const PatronTile: React.FC<Props> = ({ index, patron }) => {
   const player = patron as PlayerFragmentFragment;
+  const patronRank = computeRank(index);
   return (
     <MetaTile>
       <Box
@@ -64,23 +67,21 @@ export const PatronTile: React.FC<Props> = ({ patron }) => {
         <Wrap w="100%" justify="center">
           {patron.pSeedBalance ? (
             <WrapItem>
-              <MetaTag
-                size="md"
-              >
+              <MetaTag size="md">
                 {`pSEED: ${Math.floor(
                   Number(utils.formatEther(patron.pSeedBalance)),
                 )}`}
               </MetaTag>
             </WrapItem>
           ) : null}
-          {player.rank ? (
+          {patronRank ? (
             <WrapItem>
               <MetaTag
-                backgroundColor={player.rank?.toLowerCase()}
+                backgroundColor={patronRank?.toLowerCase()}
                 size="md"
                 color="blackAlpha.600"
               >
-                {player.rank}
+                {patronRank}
               </MetaTag>
             </WrapItem>
           ) : null}
@@ -90,9 +91,7 @@ export const PatronTile: React.FC<Props> = ({ patron }) => {
         </Wrap>
         {player.box_profile?.description ? (
           <VStack spacing={2} align="stretch">
-            <Text textStyle="caption">
-              ABOUT
-            </Text>
+            <Text textStyle="caption">ABOUT</Text>
             <Text fontSize="sm">{player.box_profile.description}</Text>
           </VStack>
         ) : null}
@@ -100,26 +99,22 @@ export const PatronTile: React.FC<Props> = ({ patron }) => {
       <MetaTileBody>
         {player.Player_Skills.length ? (
           <VStack spacing={2} align="stretch">
-            <Text textStyle="caption">
-              SKILLS
-            </Text>
-            <SkillsTags skills={player.Player_Skills.map(s => s.Skill) as Skill[]} />
+            <Text textStyle="caption">SKILLS</Text>
+            <SkillsTags
+              skills={player.Player_Skills.map((s) => s.Skill) as Skill[]}
+            />
           </VStack>
         ) : null}
 
         {player.daohausMemberships.length ? (
           <VStack spacing={2} align="stretch">
-            <Text textStyle="caption">
-              MEMBER OF
-            </Text>
+            <Text textStyle="caption">MEMBER OF</Text>
             <PlayerTileMemberships player={player} />
           </VStack>
         ) : null}
         {player.Accounts.length ? (
           <VStack spacing={2} align="stretch">
-            <Text textStyle="caption">
-              CONTACT
-            </Text>
+            <Text textStyle="caption">CONTACT</Text>
             <HStack mt="2">
               <PlayerContacts player={player} />
             </HStack>

--- a/packages/web/components/Patron/PatronTile.tsx
+++ b/packages/web/components/Patron/PatronTile.tsx
@@ -12,6 +12,7 @@ import {
   Wrap,
   WrapItem,
 } from '@metafam/ds';
+import { computeRank } from '@metafam/utils';
 import { MetaLink } from 'components/Link';
 import { PlayerContacts } from 'components/Player/PlayerContacts';
 import { PlayerTileMemberships } from 'components/Player/PlayerTileMemberships';
@@ -29,7 +30,6 @@ import {
   getPlayerImage,
   getPlayerName,
 } from 'utils/playerHelpers';
-import { computeRank } from 'utils/rankHelpers';
 
 const PATRON_RANKS = [
   PlayerRank_Enum.Diamond,

--- a/packages/web/components/PatronList.tsx
+++ b/packages/web/components/PatronList.tsx
@@ -13,8 +13,8 @@ export const PatronList: React.FC<Props> = ({ patrons }) => (
     spacing="8"
     autoRows="minmax(35rem, auto)"
   >
-    {patrons.map((p) => (
-      <PatronTile key={p.id} patron={p} />
+    {patrons.map((p, i) => (
+      <PatronTile key={p.id} patron={p} index={i} />
     ))}
   </SimpleGrid>
 );

--- a/packages/web/utils/rankHelpers.ts
+++ b/packages/web/utils/rankHelpers.ts
@@ -1,0 +1,32 @@
+import { PlayerRank_Enum } from 'graphql/autogen/types';
+
+export const RANKS = [
+  PlayerRank_Enum.Diamond,
+  PlayerRank_Enum.Platinum,
+  PlayerRank_Enum.Gold,
+  PlayerRank_Enum.Silver,
+  PlayerRank_Enum.Bronze,
+];
+
+export const PLAYERS_PER_RANK = [7, 7, 7, 14, 21];
+
+// A summation of PLAYERS_PER_RANK.
+// This is the first index for which players will NOT be ranked, e.g.
+// the 56th player will be Bronze, and the 57th player will not be ranked.
+export const RANKED_CAP: number = PLAYERS_PER_RANK.reduce((sum, rankCount) => {
+  return sum + rankCount;
+}, 0);
+
+// Computes the rank for the given index. This would be the index corresponding
+// to all players ordered by total_xp DESC.
+export function computeRank(totalRankIndex: number): PlayerRank_Enum | null {
+  if (totalRankIndex >= RANKED_CAP) return null;
+  let indexSum = 0;
+  for (let i = 0; i < PLAYERS_PER_RANK.length; i++) {
+    indexSum += PLAYERS_PER_RANK[i];
+    if (totalRankIndex < indexSum) {
+      return RANKS[i];
+    }
+  }
+  return null;
+}

--- a/packages/web/utils/rankHelpers.ts
+++ b/packages/web/utils/rankHelpers.ts
@@ -1,31 +1,24 @@
-import { PlayerRank_Enum } from 'graphql/autogen/types';
-
-export const RANKS = [
-  PlayerRank_Enum.Diamond,
-  PlayerRank_Enum.Platinum,
-  PlayerRank_Enum.Gold,
-  PlayerRank_Enum.Silver,
-  PlayerRank_Enum.Bronze,
-];
-
-export const PLAYERS_PER_RANK = [7, 7, 7, 14, 21];
-
-// A summation of PLAYERS_PER_RANK.
-// This is the first index for which players will NOT be ranked, e.g.
-// the 56th player will be Bronze, and the 57th player will not be ranked.
-export const RANKED_CAP: number = PLAYERS_PER_RANK.reduce((sum, rankCount) => {
-  return sum + rankCount;
-}, 0);
+// A summation of usersPerRank
+// This is the first index for which users will NOT be ranked
+const computeRankCap = (usersPerRank: Array<number>) =>
+  usersPerRank.reduce((sum, rankCount) => {
+    return sum + rankCount;
+  }, 0);
 
 // Computes the rank for the given index. This would be the index corresponding
 // to all players ordered by total_xp DESC.
-export function computeRank(totalRankIndex: number): PlayerRank_Enum | null {
-  if (totalRankIndex >= RANKED_CAP) return null;
+export function computeRank(
+  rankIndex: number,
+  usersPerRank: Array<number>,
+  ranks: Array<string>,
+): string | null {
+  const rankCap = computeRankCap(usersPerRank);
+  if (rankIndex >= rankCap) return null;
   let indexSum = 0;
-  for (let i = 0; i < PLAYERS_PER_RANK.length; i++) {
-    indexSum += PLAYERS_PER_RANK[i];
-    if (totalRankIndex < indexSum) {
-      return RANKS[i];
+  for (let i = 0; i < usersPerRank.length; i++) {
+    indexSum += usersPerRank[i];
+    if (rankIndex < indexSum && i < ranks.length) {
+      return ranks[i];
     }
   }
   return null;


### PR DESCRIPTION
@alalonde I've copied that code you've used in the `@metafam/backend` onto `@metafam/web` for computing the rank.

Definitely think we should have this code in a single place. Perhaps in `@metafam/utils` but that would require moving the hasura graphql types as well, which seems unnecessary right now.

anyways let me know what you think.