### PR TITLE
allow aggregations in player table

### DIFF
--- a/hasura/metadata/tables.yaml
+++ b/hasura/metadata/tables.yaml
@@ -315,6 +315,7 @@
       - timezone
       - username
       filter: {}
+      allow_aggregations: true
   - role: public
     permission:
       columns:
@@ -328,6 +329,7 @@
       - timezone
       - username
       filter: {}
+      allow_aggregations: true
   update_permissions:
   - role: player
     permission:


### PR DESCRIPTION
Need this to have run aggregate queries on the players table.
This is particularly needed for pagination to figure out number of pages that are there for a particular filter in `/players` page.