### PR TITLE
Use environment variable for SourceCred ledger branch

### DIFF
--- a/packages/backend/src/config.ts
+++ b/packages/backend/src/config.ts
@@ -10,7 +10,7 @@ interface IConfig {
   infuraId: string;
   pSEEDAddress: string;
   brightIdAppUrl: string;
-  discordBotToken: string;
+  sourceCredLedgerBranch: string;
 }
 
 function parseEnv<T extends string | number>(
@@ -63,5 +63,8 @@ export const CONFIG: IConfig = {
     process.env.NEXT_BRIGHTID_APP_URL,
     'https://app.brightid.org',
   ),
-  discordBotToken: parseEnv(process.env.DISCORD_BOT_TOKEN, ''),
+  sourceCredLedgerBranch: parseEnv(
+    process.env.SOURCECRED_LEDGER_BRANCH,
+    'staging', // Just so we dont mess up the master ledger in case people are testing locally
+  ),
 };

--- a/packages/backend/src/lib/sourcecredLedger.ts
+++ b/packages/backend/src/lib/sourcecredLedger.ts
@@ -6,7 +6,7 @@ import { CONFIG } from '../config';
 const storage = new sourcecred.ledger.storage.GithubStorage({
   apiToken: CONFIG.githubApiToken,
   repo: 'MetaFam/XP',
-  branch: 'master',
+  branch: CONFIG.sourceCredLedgerBranch,
 });
 
 export const ledgerManager: LedgerManager = new sourcecred.ledger.manager.LedgerManager(

--- a/packages/discord-bot/src/config.ts
+++ b/packages/discord-bot/src/config.ts
@@ -9,6 +9,7 @@ interface IConfig {
   githubApiToken: string;
   discordBotToken: string;
   discordBotClientSecret: string;
+  sourceCredLedgerBranch: string;
 }
 
 function parseEnv<T extends string | number>(
@@ -42,4 +43,8 @@ export const CONFIG: IConfig = {
   githubApiToken: parseEnv(process.env.GITHUB_API_TOKEN, ''),
   discordBotToken: parseEnv(process.env.DISCORD_BOT_TOKEN, ''),
   discordBotClientSecret: parseEnv(process.env.DISCORD_BOT_CLIENT_SECRET, ''),
+  sourceCredLedgerBranch: parseEnv(
+    process.env.SOURCECRED_LEDGER_BRANCH,
+    'staging', // Just so we dont mess up the master ledger in case people are testing locally
+  ),
 };

--- a/packages/discord-bot/src/sourcecred.ts
+++ b/packages/discord-bot/src/sourcecred.ts
@@ -5,7 +5,7 @@ import { CONFIG } from './config';
 const storage = new sourcecred.ledger.storage.GithubStorage({
   apiToken: CONFIG.githubApiToken,
   repo: 'MetaFam/XP',
-  branch: 'master',
+  branch: CONFIG.sourceCredLedgerBranch,
 });
 
 export const manager: LedgerManager = new sourcecred.ledger.manager.LedgerManager(

--- a/render.yaml
+++ b/render.yaml
@@ -15,6 +15,8 @@ services:
       - fromGroup: discord-secrets
       - fromGroup: github-secrets
       - fromGroup: backend-secrets
+      - key: SOURCECRED_LEDGER_BRANCH
+        value: master
       - key: GRAPHQL_HOST
         fromService:
           name: hasura
@@ -108,6 +110,8 @@ services:
         value: 5000
       - key: FRONTEND_URL
         value: https://my.metagame.wtf
+      - key: SOURCECRED_LEDGER_BRANCH
+        value: master
       - key: GRAPHQL_HOST
         fromService:
           name: hasura


### PR DESCRIPTION
This prevents people from accidentally mesing up the master ledger in local / staging environments.