### PR TITLE
Backend only: add Polygon and xDai chains for DAO membership

### DIFF
--- a/packages/backend/src/config.ts
+++ b/packages/backend/src/config.ts
@@ -2,6 +2,8 @@ interface IConfig {
   port: number;
   graphqlURL: string;
   daoHausGraphqlURL: string;
+  daoHausPolygonGraphqlURL: string;
+  daoHausXdaiGraphqlURL: string;
   seedGraphqlURL: string;
   adminKey: string;
   ipfsEndpoint: string;
@@ -42,6 +44,14 @@ export const CONFIG: IConfig = {
   daoHausGraphqlURL: parseEnv(
     process.env.DAOHAUS_GRAPHQL_URL,
     'https://api.thegraph.com/subgraphs/name/odyssy-automaton/daohaus',
+  ),
+  daoHausPolygonGraphqlURL: parseEnv(
+    process.env.DAOUHAUS_POLYGON_GRAPHQL_URL,
+    'https://api.thegraph.com/subgraphs/name/odyssy-automaton/daohaus-matic',
+  ),
+  daoHausXdaiGraphqlURL: parseEnv(
+    process.env.DAOUHAUS_XDAI_GRAPHQL_URL,
+    'https://api.thegraph.com/subgraphs/name/odyssy-automaton/daohaus-xdai',
   ),
   adminKey: parseEnv(
     process.env.HASURA_GRAPHQL_ADMIN_SECRET,

--- a/packages/backend/src/handlers/remote-schemas/resolvers/daohaus/resolver.ts
+++ b/packages/backend/src/handlers/remote-schemas/resolvers/daohaus/resolver.ts
@@ -1,8 +1,8 @@
-import { clientFactory } from '../../../../lib/daoHausClient';
+import { getClient } from '../../../../lib/daoHausClient';
 import { Member, QueryResolvers } from '../../autogen/types';
 
 const addChain = (memberAddress: string) => async (chain: string) => {
-  const client = clientFactory(chain);
+  const client = getClient(chain);
   const members = <Member[]>(
     (await client.GetDaoHausMemberships({ memberAddress })).members
   );

--- a/packages/backend/src/handlers/remote-schemas/resolvers/daohaus/resolver.ts
+++ b/packages/backend/src/handlers/remote-schemas/resolvers/daohaus/resolver.ts
@@ -1,12 +1,37 @@
-import { daoHausClient } from '../../../../lib/daoHausClient';
-import { QueryResolvers } from '../../autogen/types';
+import { clientFactory } from '../../../../lib/daoHausClient';
+import { Member, QueryResolvers } from '../../autogen/types';
+
+const addChain = (memberAddress: string) => async (chain: string) => {
+  const client = clientFactory(chain);
+  const members = <Member[]>(
+    (await client.GetDaoHausMemberships({ memberAddress })).members
+  );
+
+  return members.map((member: Member) => {
+    const updatedMember: Member = { ...member };
+    updatedMember.moloch.chain = chain;
+    return updatedMember;
+  });
+};
 
 export const getDaoHausMemberships: QueryResolvers['getDaoHausMemberships'] = async (
   _,
   { memberAddress },
 ) => {
   if (!memberAddress) return [];
-  const res = await daoHausClient.GetDaoHausMemberships({ memberAddress });
 
-  return res.members;
+  const membershipsOn = addChain(memberAddress);
+
+  const res = await Promise.all([
+    membershipsOn('ethereum'),
+    membershipsOn('polygon'),
+    membershipsOn('xdai'),
+  ]);
+
+  const members: Member[] = res.reduce(
+    (allMembers, networkMembers) => [...allMembers, ...networkMembers],
+    <Member[]>[],
+  );
+
+  return members;
 };

--- a/packages/backend/src/handlers/remote-schemas/resolvers/daohaus/resolver.ts
+++ b/packages/backend/src/handlers/remote-schemas/resolvers/daohaus/resolver.ts
@@ -10,6 +10,10 @@ const addChain = (memberAddress: string) => async (chain: string) => {
   return members.map((member: Member) => {
     const updatedMember: Member = { ...member };
     updatedMember.moloch.chain = chain;
+
+    if (!member.moloch.title)
+      updatedMember.moloch.title = `Unknown ${chain} DAO`;
+
     return updatedMember;
   });
 };
@@ -22,14 +26,14 @@ export const getDaoHausMemberships: QueryResolvers['getDaoHausMemberships'] = as
 
   const membershipsOn = addChain(memberAddress);
 
-  const res = await Promise.all([
+  const memberships = await Promise.all([
     membershipsOn('ethereum'),
     membershipsOn('polygon'),
     membershipsOn('xdai'),
   ]);
 
-  const members: Member[] = res.reduce(
-    (allMembers, networkMembers) => [...allMembers, ...networkMembers],
+  const members: Member[] = memberships.reduce(
+    (allMembers, chainMembers) => [...allMembers, ...chainMembers],
     <Member[]>[],
   );
 

--- a/packages/backend/src/handlers/remote-schemas/typeDefs.ts
+++ b/packages/backend/src/handlers/remote-schemas/typeDefs.ts
@@ -43,6 +43,7 @@ export const typeDefs = gql`
     version: String
     totalShares: String!
     totalLoot: String!
+    chain: String!
   }
 
   type Member {

--- a/packages/backend/src/lib/daoHausClient.ts
+++ b/packages/backend/src/lib/daoHausClient.ts
@@ -3,13 +3,13 @@ import { GraphQLClient } from 'graphql-request';
 import { CONFIG } from '../config';
 import { getSdk, Sdk } from './autogen/daohaus-sdk';
 
-export function clientFactory(chain: string): Sdk {
-  switch (chain) {
-    case 'polygon':
-      return getSdk(new GraphQLClient(CONFIG.daoHausPolygonGraphqlURL));
-    case 'xdai':
-      return getSdk(new GraphQLClient(CONFIG.daoHausXdaiGraphqlURL));
-    default:
-      return getSdk(new GraphQLClient(CONFIG.daoHausGraphqlURL));
-  }
+const defaultGqlClient = new GraphQLClient(CONFIG.daoHausGraphqlURL);
+const clients = new Map([
+  ['polygon', new GraphQLClient(CONFIG.daoHausPolygonGraphqlURL)],
+  ['xdai', new GraphQLClient(CONFIG.daoHausXdaiGraphqlURL)],
+  ['ethereum', defaultGqlClient],
+]);
+
+export function getClient(chain: string): Sdk {
+  return getSdk(clients.get(chain) || defaultGqlClient);
 }

--- a/packages/backend/src/lib/daoHausClient.ts
+++ b/packages/backend/src/lib/daoHausClient.ts
@@ -1,8 +1,15 @@
 import { GraphQLClient } from 'graphql-request';
 
 import { CONFIG } from '../config';
-import { getSdk } from './autogen/daohaus-sdk';
+import { getSdk, Sdk } from './autogen/daohaus-sdk';
 
-export const daoHausClient = getSdk(
-  new GraphQLClient(CONFIG.daoHausGraphqlURL),
-);
+export function clientFactory(chain: string): Sdk {
+  switch (chain) {
+    case 'polygon':
+      return getSdk(new GraphQLClient(CONFIG.daoHausPolygonGraphqlURL));
+    case 'xdai':
+      return getSdk(new GraphQLClient(CONFIG.daoHausXdaiGraphqlURL));
+    default:
+      return getSdk(new GraphQLClient(CONFIG.daoHausGraphqlURL));
+  }
+}

--- a/packages/backend/src/lib/daoHausClient.ts
+++ b/packages/backend/src/lib/daoHausClient.ts
@@ -3,13 +3,18 @@ import { GraphQLClient } from 'graphql-request';
 import { CONFIG } from '../config';
 import { getSdk, Sdk } from './autogen/daohaus-sdk';
 
-const defaultGqlClient = new GraphQLClient(CONFIG.daoHausGraphqlURL);
 const clients = new Map([
   ['polygon', new GraphQLClient(CONFIG.daoHausPolygonGraphqlURL)],
   ['xdai', new GraphQLClient(CONFIG.daoHausXdaiGraphqlURL)],
-  ['ethereum', defaultGqlClient],
+  ['ethereum', new GraphQLClient(CONFIG.daoHausGraphqlURL)],
 ]);
 
 export function getClient(chain: string): Sdk {
-  return getSdk(clients.get(chain) || defaultGqlClient);
+  const gqlClient = clients.get(chain);
+  if (!gqlClient)
+    throw new Error(
+      `The '${chain}' chain is unrecognized, unable to create GQL Client`,
+    );
+
+  return getSdk(gqlClient);
 }

--- a/schema.graphql
+++ b/schema.graphql
@@ -2096,6 +2096,7 @@ type Member {
 }
 
 type Moloch {
+  chain: String!
   id: ID!
   summoner: String!
   title: String


### PR DESCRIPTION
This uses two new subgraphs to pull DAO memberships for Ethereum, xDai, and Polygon mainnets. The pulls are in parallel. The underlying data is structured the same way but seems to be missing some information, see https://github.com/HausDAO/daohaus-supergraph/issues/44.

These are backend only changes and so the UI is a little bit wonky. Since some DAOs will have no title, there is a default that follows the format of `Unknown ${chain} DAO`. This is pretty meaningless but more meaningful than showing a blank title. Frontend changes will be required to make this look better.

This is split from #581.

## Screenshots

*Before*:

Only Ethereum mainnet DAOs

![643-before](https://user-images.githubusercontent.com/621541/121441414-992dc100-c93e-11eb-808a-2a33904acd6d.png)

*After*:

You can see that there are a number of DAOs without titles

![643-altchain-default-title](https://user-images.githubusercontent.com/621541/121440919-af874d00-c93d-11eb-8ed1-63b316830e5f.png)