### PR TITLE
Multichain DAO tests + log noise reduction

### DIFF
--- a/packages/backend/package.json
+++ b/packages/backend/package.json
@@ -48,6 +48,7 @@
   "devDependencies": {
     "concurrently": "6.1.0",
     "eslint-plugin-jest": "24.3.6",
+    "nock": "^13.1.0",
     "ts-node-dev": "1.1.6"
   }
 }

--- a/packages/backend/package.json
+++ b/packages/backend/package.json
@@ -48,7 +48,7 @@
   "devDependencies": {
     "concurrently": "6.1.0",
     "eslint-plugin-jest": "24.3.6",
-    "nock": "^13.1.0",
+    "nock": "13.1.0",
     "ts-node-dev": "1.1.6"
   }
 }

--- a/packages/backend/src/handlers/remote-schemas/resolvers/daohaus/resolver.ts
+++ b/packages/backend/src/handlers/remote-schemas/resolvers/daohaus/resolver.ts
@@ -38,7 +38,7 @@ export const getDaoHausMemberships: QueryResolvers['getDaoHausMemberships'] = as
 
   const members: Member[] = memberships.reduce((allMembers, chainMembers) => {
     if (chainMembers.status === 'rejected') {
-      console.error('Pulling memberships failed:', chainMembers.reason);
+      console.warn('Pulling memberships failed:', chainMembers.reason);
       return allMembers;
     }
 

--- a/packages/backend/tests/handlers/remote-schemas/resolvers/daohaus/resolver.test.ts
+++ b/packages/backend/tests/handlers/remote-schemas/resolvers/daohaus/resolver.test.ts
@@ -4,17 +4,17 @@ import { Resolver } from '../../../../../src/handlers/remote-schemas/autogen/typ
 import { getDaoHausMemberships } from '../../../../../src/handlers/remote-schemas/resolvers/daohaus/resolver';
 
 type MockResolver<TResult, TParent, TContext, TArgs> = (
-    parent?: TParent | any,
-    args?: TArgs | any,
-    context?: TContext | any,
-    info?: any
+  parent?: TParent | any,
+  args?: TArgs | any,
+  context?: TContext | any,
+  info?: any,
 ) => Promise<TResult> | TResult;
 
 function mockResolver<TResult, TParent, TContext, TArgs>(
-    resolver: Resolver<TResult, TParent, TContext, TArgs>
+  resolver: Resolver<TResult, TParent, TContext, TArgs>,
 ): MockResolver<TResult, TParent, TContext, TArgs> {
-    return (parent: TParent, args: TArgs, context: TContext, info) =>
-      resolver(parent, args, context, info);
+  return (parent: TParent, args: TArgs, context: TContext, info) =>
+    resolver(parent, args, context, info);
 }
 
 // NOTE for integration tests, this address always needs to be part of at least one dao
@@ -31,39 +31,38 @@ describe('getDaoHausMemberships', () => {
   it('should look for associated DAOs on ethereum, polygon, and xdai', async () => {
     const membershipResolver = mockResolver(getDaoHausMemberships);
 
-    const members = [{ moloch: {} }]
+    const members = [{ moloch: {} }];
 
     const ethGraph = nock('https://api.thegraph.com:443')
       .post('/subgraphs/name/odyssy-automaton/daohaus')
-      .reply(200, { data: { members } })
+      .reply(200, { data: { members } });
 
     const xdaiGraph = nock('https://api.thegraph.com:443')
       .post('/subgraphs/name/odyssy-automaton/daohaus-xdai')
-      .reply(200, { data: { members } })
+      .reply(200, { data: { members } });
 
     const polygonGraph = nock('https://api.thegraph.com:443')
       .post('/subgraphs/name/odyssy-automaton/daohaus-matic')
-      .reply(200, { data: { members } })
+      .reply(200, { data: { members } });
 
-    // nock.recorder.rec();
     const result = await membershipResolver(
       {},
-      { memberAddress: VALID_ADDRESS }
+      { memberAddress: VALID_ADDRESS },
     );
 
-    const moloch = (chain: string) => expect.objectContaining({ chain })
+    const moloch = (chain: string) => expect.objectContaining({ chain });
 
     expect(result).toContainEqual({
-      moloch: moloch('ethereum')
-    })
+      moloch: moloch('ethereum'),
+    });
 
     expect(result).toContainEqual({
-      moloch: moloch('xdai')
-    })
+      moloch: moloch('xdai'),
+    });
 
     expect(result).toContainEqual({
-      moloch: moloch('polygon')
-    })
+      moloch: moloch('polygon'),
+    });
 
     expect(ethGraph.isDone()).toBeTruthy();
     expect(xdaiGraph.isDone()).toBeTruthy();
@@ -73,39 +72,38 @@ describe('getDaoHausMemberships', () => {
   it('should gracefully handle failure', async () => {
     const membershipResolver = mockResolver(getDaoHausMemberships);
 
-    const members = [{ moloch: {} }]
+    const members = [{ moloch: {} }];
 
     const ethGraph = nock('https://api.thegraph.com:443')
       .post('/subgraphs/name/odyssy-automaton/daohaus')
-      .reply(200, { data: { members } })
+      .reply(200, { data: { members } });
 
     const xdaiGraph = nock('https://api.thegraph.com:443')
       .post('/subgraphs/name/odyssy-automaton/daohaus-xdai')
-      .reply(400, { error: {} })
+      .reply(400, { error: {} });
 
     const polygonGraph = nock('https://api.thegraph.com:443')
       .post('/subgraphs/name/odyssy-automaton/daohaus-matic')
-      .reply(200, { data: { members } })
+      .reply(200, { data: { members } });
 
-    // nock.recorder.rec();
     const result = await membershipResolver(
       {},
-      { memberAddress: VALID_ADDRESS }
+      { memberAddress: VALID_ADDRESS },
     );
 
-    const moloch = (chain: string) => expect.objectContaining({ chain })
+    const moloch = (chain: string) => expect.objectContaining({ chain });
 
     expect(result).toContainEqual({
-      moloch: moloch('ethereum')
-    })
+      moloch: moloch('ethereum'),
+    });
 
     expect(result).not.toContainEqual({
-      moloch: moloch('xdai')
-    })
+      moloch: moloch('xdai'),
+    });
 
     expect(result).toContainEqual({
-      moloch: moloch('polygon')
-    })
+      moloch: moloch('polygon'),
+    });
 
     expect(ethGraph.isDone()).toBeTruthy();
     expect(xdaiGraph.isDone()).toBeTruthy();

--- a/packages/backend/tests/handlers/remote-schemas/resolvers/daohaus/resolver.test.ts
+++ b/packages/backend/tests/handlers/remote-schemas/resolvers/daohaus/resolver.test.ts
@@ -20,6 +20,8 @@ function mockResolver<TResult, TParent, TContext, TArgs>(
 // NOTE for integration tests, this address always needs to be part of at least one dao
 const VALID_ADDRESS = '0xb53b0255895c4f9e3a185e484e5b674bccfbc076';
 
+const matchingMoloch = (chain: string) => expect.objectContaining({ chain });
+
 describe('getDaoHausMemberships', () => {
   it('should return an empty array when no wallet address passed', async () => {
     const membershipResolver = mockResolver(getDaoHausMemberships);
@@ -46,16 +48,14 @@ describe('getDaoHausMemberships', () => {
       { memberAddress: VALID_ADDRESS },
     );
 
-    const moloch = (chain: string) => expect.objectContaining({ chain });
-
     expect(result).toContainEqual({
-      moloch: moloch('ethereum'),
+      moloch: matchingMoloch('ethereum'),
     });
     expect(result).toContainEqual({
-      moloch: moloch('xdai'),
+      moloch: matchingMoloch('xdai'),
     });
     expect(result).toContainEqual({
-      moloch: moloch('polygon'),
+      moloch: matchingMoloch('polygon'),
     });
 
     expect(graphs.isDone()).toBeTruthy();
@@ -69,28 +69,25 @@ describe('getDaoHausMemberships', () => {
     const graphs = nock('https://api.thegraph.com:443')
       .post('/subgraphs/name/odyssy-automaton/daohaus')
       .reply(200, { data: { members } })
-      .post('/subgraphs/name/odyssy-automaton/daohaus-xdai')
-      .reply(400, { errors: [{ message: 'Subgraph unavailable' }] })
       .post('/subgraphs/name/odyssy-automaton/daohaus-matic')
-      .reply(200, { data: { members } });
+      .reply(200, { data: { members } })
+      .post('/subgraphs/name/odyssy-automaton/daohaus-xdai')
+      .reply(400, { errors: [{ message: 'Subgraph unavailable' }] });
 
     const result = await membershipResolver(
       {},
       { memberAddress: VALID_ADDRESS },
     );
 
-    const moloch = (chain: string) => expect.objectContaining({ chain });
-
     expect(result).toContainEqual({
-      moloch: moloch('ethereum'),
+      moloch: matchingMoloch('ethereum'),
+    });
+    expect(result).toContainEqual({
+      moloch: matchingMoloch('polygon'),
     });
 
     expect(result).not.toContainEqual({
-      moloch: moloch('xdai'),
-    });
-
-    expect(result).toContainEqual({
-      moloch: moloch('polygon'),
+      moloch: matchingMoloch('xdai'),
     });
 
     expect(graphs.isDone()).toBeTruthy();

--- a/packages/backend/tests/handlers/remote-schemas/resolvers/daohaus/resolver.test.ts
+++ b/packages/backend/tests/handlers/remote-schemas/resolvers/daohaus/resolver.test.ts
@@ -1,0 +1,74 @@
+import nock from 'nock';
+
+import { Resolver } from '../../../../../src/handlers/remote-schemas/autogen/types';
+import { getDaoHausMemberships } from '../../../../../src/handlers/remote-schemas/resolvers/daohaus/resolver';
+
+type MockResolver<TResult, TParent, TContext, TArgs> = (
+    parent?: TParent | any,
+    args?: TArgs | any,
+    context?: TContext | any,
+    info?: any
+) => Promise<TResult> | TResult;
+
+function mockResolver<TResult, TParent, TContext, TArgs>(
+    resolver: Resolver<TResult, TParent, TContext, TArgs>
+): MockResolver<TResult, TParent, TContext, TArgs> {
+    return (parent: TParent, args: TArgs, context: TContext, info) =>
+      resolver(parent, args, context, info);
+}
+
+// NOTE for integration tests, this address always needs to be part of at least one dao
+const VALID_ADDRESS = '0xb53b0255895c4f9e3a185e484e5b674bccfbc076';
+
+describe('getDaoHausMemberships', () => {
+  it('should return an empty array when no wallet address passed', async () => {
+    const membershipResolver = mockResolver(getDaoHausMemberships);
+
+    const members = await membershipResolver({}, {});
+    expect(members).toStrictEqual([]);
+  });
+
+  it('should look for associated DAOs on ethereum, polygon, and xdai', async () => {
+    const membershipResolver = mockResolver(getDaoHausMemberships);
+
+    const members = [{ moloch: {} }]
+
+    const ethGraph = nock('https://api.thegraph.com:443')
+      .post('/subgraphs/name/odyssy-automaton/daohaus')
+      .reply(200, { data: { members } })
+
+    const xdaiGraph = nock('https://api.thegraph.com:443')
+      .post('/subgraphs/name/odyssy-automaton/daohaus-xdai')
+      .reply(200, { data: { members } })
+
+    const polygonGraph = nock('https://api.thegraph.com:443')
+      .post('/subgraphs/name/odyssy-automaton/daohaus-matic')
+      .reply(200, { data: { members } })
+
+    // nock.recorder.rec();
+    const result = await membershipResolver(
+      {},
+      { memberAddress: VALID_ADDRESS }
+    );
+
+    const moloch = (chain: string) => expect.objectContaining({ chain })
+
+    expect(result).toContainEqual({
+      moloch: moloch('ethereum')
+    })
+
+    expect(result).toContainEqual({
+      moloch: moloch('xdai')
+    })
+
+    expect(result).toContainEqual({
+      moloch: moloch('polygon')
+    })
+
+    expect(ethGraph.isDone()).toBeTruthy();
+    expect(xdaiGraph.isDone()).toBeTruthy();
+    expect(polygonGraph.isDone()).toBeTruthy();
+  });
+});
+
+

--- a/packages/backend/tests/lib/daoHausClient.test.ts
+++ b/packages/backend/tests/lib/daoHausClient.test.ts
@@ -1,0 +1,11 @@
+import { getClient } from '../../src/lib/daoHausClient';
+
+describe('daoHausClient', () => {
+  it('should throw error for unknown chain', () => {
+    expect(() => getClient('garbage')).toThrow();
+  });
+
+  it('should return a client when chain is configured', () => {
+    expect(getClient('ethereum')).toBeDefined();
+  });
+});

--- a/packages/backend/tsconfig.json
+++ b/packages/backend/tsconfig.json
@@ -15,5 +15,5 @@
       "path": "../discord-bot"
     }
   ],
-  "include": ["./src"]
+  "include": ["./src", "./tests"]
 }

--- a/packages/backend/tsconfig.json
+++ b/packages/backend/tsconfig.json
@@ -15,5 +15,5 @@
       "path": "../discord-bot"
     }
   ],
-  "include": ["./src", "./tests"]
+  "include": ["./src"]
 }

--- a/packages/backend/tsconfig.json
+++ b/packages/backend/tsconfig.json
@@ -4,6 +4,7 @@
     "module": "commonjs",
     "rootDir": "src",
     "outDir": "dist",
+    "esModuleInterop": true,
     "tsBuildInfoFile": "dist/.tsbuildinfo"
   },
   "references": [

--- a/yarn.lock
+++ b/yarn.lock
@@ -21529,7 +21529,7 @@ no-case@^3.0.4:
     lower-case "^2.0.2"
     tslib "^2.0.3"
 
-nock@^13.1.0:
+nock@13.1.0:
   version "13.1.0"
   resolved "https://registry.yarnpkg.com/nock/-/nock-13.1.0.tgz#41c8ce8b35ab7d618c4cbf40de1d5bce319979ba"
   integrity sha512-3N3DUY8XYrxxzWazQ+nSBpiaJ3q6gcpNh4gXovC/QBxrsvNp4tq+wsLHF6mJ3nrn3lPLn7KCJqKxy/9aD+0fdw==

--- a/yarn.lock
+++ b/yarn.lock
@@ -20149,6 +20149,11 @@ lodash.repeat@4.1.0:
   resolved "https://registry.yarnpkg.com/lodash.repeat/-/lodash.repeat-4.1.0.tgz#fc7de8131d8c8ac07e4b49f74ffe829d1f2bec44"
   integrity sha1-/H3oEx2MisB+S0n3T/6CnR8r7EQ=
 
+lodash.set@^4.3.2:
+  version "4.3.2"
+  resolved "https://registry.yarnpkg.com/lodash.set/-/lodash.set-4.3.2.tgz#d8757b1da807dde24816b0d6a84bea1a76230b23"
+  integrity sha1-2HV7HagH3eJIFrDWqEvqGnYjCyM=
+
 lodash.sortby@^4.7.0:
   version "4.7.0"
   resolved "https://registry.yarnpkg.com/lodash.sortby/-/lodash.sortby-4.7.0.tgz#edd14c824e2cc9c1e0b0a1b42bb5210516a42438"
@@ -21523,6 +21528,16 @@ no-case@^3.0.4:
   dependencies:
     lower-case "^2.0.2"
     tslib "^2.0.3"
+
+nock@^13.1.0:
+  version "13.1.0"
+  resolved "https://registry.yarnpkg.com/nock/-/nock-13.1.0.tgz#41c8ce8b35ab7d618c4cbf40de1d5bce319979ba"
+  integrity sha512-3N3DUY8XYrxxzWazQ+nSBpiaJ3q6gcpNh4gXovC/QBxrsvNp4tq+wsLHF6mJ3nrn3lPLn7KCJqKxy/9aD+0fdw==
+  dependencies:
+    debug "^4.1.0"
+    json-stringify-safe "^5.0.1"
+    lodash.set "^4.3.2"
+    propagate "^2.0.0"
 
 node-abi@^2.21.0:
   version "2.26.0"
@@ -23704,6 +23719,11 @@ prop-types@15.7.2, prop-types@^15.0.0, prop-types@^15.5.8, prop-types@^15.6.0, p
     loose-envify "^1.4.0"
     object-assign "^4.1.1"
     react-is "^16.8.1"
+
+propagate@^2.0.0:
+  version "2.0.1"
+  resolved "https://registry.yarnpkg.com/propagate/-/propagate-2.0.1.tgz#40cdedab18085c792334e64f0ac17256d38f9a45"
+  integrity sha512-vGrhOavPSTz4QVNuBNdcNXePNdNMaO1xj9yBeH1ScQPjk/rhg9sSlCXPhMkFuaNNW/syTvYqsnbIJxMBfRbbag==
 
 proper-lockfile@^4.0.0, proper-lockfile@^4.1.1:
   version "4.1.2"


### PR DESCRIPTION
Related: #687 

---

This adds tests to the daohaus resolver as there is some logic in pulling more than one subgraph.

There is a small tweak to the resolver under test to change the `console.error` to `console.warn` as the request failing is covered by providing a default value.