### PR TITLE
The color display on a player's profile is broken #716 **fixed** 

### DIFF
--- a/packages/web/components/Player/Section/PlayerHero.tsx
+++ b/packages/web/components/Player/Section/PlayerHero.tsx
@@ -92,9 +92,9 @@ export const PlayerHero: React.FC<Props> = ({ player }) => {
               )}`}
               maxH="6rem"
             >
-             
+              
                 <ColorBar mask={type.mask} />
-         
+              
             </Link>
             <Text color="blueLight" mt={4} style={{ textIndent: 16 }}>
               {type.description}

--- a/packages/web/components/Player/Section/PlayerHero.tsx
+++ b/packages/web/components/Player/Section/PlayerHero.tsx
@@ -93,7 +93,7 @@ export const PlayerHero: React.FC<Props> = ({ player }) => {
               maxH="6rem"
             >
               
-                <ColorBar mask={type.mask} />
+              <ColorBar mask={type.mask} />
               
             </Link>
             <Text color="blueLight" mt={4} style={{ textIndent: 16 }}>

--- a/packages/web/components/Player/Section/PlayerHero.tsx
+++ b/packages/web/components/Player/Section/PlayerHero.tsx
@@ -93,7 +93,6 @@ export const PlayerHero: React.FC<Props> = ({ player }) => {
               maxH="6rem"
             >
               <ColorBar mask={type.mask} />
-              
             </Link>
             <Text color="blueLight" mt={4} style={{ textIndent: 16 }}>
               {type.description}

--- a/packages/web/components/Player/Section/PlayerHero.tsx
+++ b/packages/web/components/Player/Section/PlayerHero.tsx
@@ -92,7 +92,6 @@ export const PlayerHero: React.FC<Props> = ({ player }) => {
               )}`}
               maxH="6rem"
             >
-              
               <ColorBar mask={type.mask} />
               
             </Link>

--- a/packages/web/components/Player/Section/PlayerHero.tsx
+++ b/packages/web/components/Player/Section/PlayerHero.tsx
@@ -92,9 +92,9 @@ export const PlayerHero: React.FC<Props> = ({ player }) => {
               )}`}
               maxH="6rem"
             >
-              <Flex justify="center">
+             
                 <ColorBar mask={type.mask} />
-              </Flex>
+         
             </Link>
             <Text color="blueLight" mt={4} style={{ textIndent: 16 }}>
               {type.description}


### PR DESCRIPTION
https://github.com/MetaFam/TheGame/issues/716

Fixed issue causing extra whitespace on the color display on player profile. 

Hopefully this fixes the issue. Tested on edge and it appears to be working as intended now from my end. 

Hope this helps! 