### PR TITLE
resolve moloch titles after DaoHaus schema change

### DIFF
--- a/packages/backend/src/handlers/remote-schemas/resolvers/daohaus/queries.ts
+++ b/packages/backend/src/handlers/remote-schemas/resolvers/daohaus/queries.ts
@@ -15,13 +15,21 @@ export const GetDaoHausMemberships = gql`
       kicked
       moloch {
         id
-        title
         version
         summoner
         totalShares
         totalLoot
       }
       delegateKey
+    }
+  }
+`;
+
+export const GetDaoHausTitles = gql`
+  query GetDaoHausTitles($ids: [ID!]) {
+    daoMetas(where: { id_in: $ids }) {
+      id
+      title
     }
   }
 `;

--- a/packages/backend/src/handlers/remote-schemas/resolvers/daohaus/resolver.ts
+++ b/packages/backend/src/handlers/remote-schemas/resolvers/daohaus/resolver.ts
@@ -7,9 +7,17 @@ const addChain = (memberAddress: string) => async (chain: string) => {
     (await client.GetDaoHausMemberships({ memberAddress })).members
   );
 
+  const ids = members.map(({ moloch: { id } }) => id);
+  const { daoMetas } = await client.GetDaoHausTitles({ ids });
+
+  const titles = Object.fromEntries(
+    daoMetas.map(({ id, title }) => [id, title]),
+  );
+
   return members.map((member: Member) => {
     const updatedMember: Member = { ...member };
     updatedMember.moloch.chain = chain;
+    updatedMember.moloch.title = titles[member.moloch.id];
 
     return updatedMember;
   });


### PR DESCRIPTION
Cause of DaoHaus changes in their schema we had failures during build.
The moloch title was moved to the metadata schema.

paired-with: @dysbulic 