### PR TITLE
MyMeta Fix: Nested Link Error

### DIFF
--- a/packages/web/components/Player/PlayerTile.tsx
+++ b/packages/web/components/Player/PlayerTile.tsx
@@ -13,7 +13,6 @@ import {
   Wrap,
   WrapItem,
 } from '@metafam/ds';
-import { MetaLink } from 'components/Link';
 import { PlayerAvatar } from 'components/Player/PlayerAvatar';
 import { PlayerContacts } from 'components/Player/PlayerContacts';
 import { PlayerTileMemberships } from 'components/Player/PlayerTileMemberships';

--- a/packages/web/components/Player/PlayerTile.tsx
+++ b/packages/web/components/Player/PlayerTile.tsx
@@ -48,31 +48,25 @@ export const PlayerTile: React.FC<Props> = ({ player }) => {
       : description;
   return (
     <LinkBox>
-      <LinkOverlay href={`/player/${player.username}`}>
-        <MetaTile>
-          <Box
-            bgImage={`url(${getPlayerCoverImage(player)})`}
-            bgSize="cover"
-            bgPosition="center"
-            position="absolute"
-            top="0"
-            left="0"
-            w="100%"
-            h="4.5rem"
-          />
+      <MetaTile>
+        <Box
+          bgImage={`url(${getPlayerCoverImage(player)})`}
+          bgSize="cover"
+          bgPosition="center"
+          position="absolute"
+          top={0}
+          left={0}
+          w="100%"
+          h="4.5rem"
+        />
+        <LinkOverlay href={`/player/${player.username}`}>
           <MetaTileHeader>
-            <MetaLink
-              as={`/player/${player.username}`}
-              href="/player/[username]"
-              key={player.id}
-            >
-              <VStack>
-                <PlayerAvatar player={player} size="xl" />
-                <Heading size="xs" color="white">
-                  {getPlayerName(player)}
-                </Heading>
-              </VStack>
-            </MetaLink>
+            <VStack>
+              <PlayerAvatar player={player} size="xl" />
+              <Heading size="xs" color="white">
+                {getPlayerName(player)}
+              </Heading>
+            </VStack>
             <Wrap w="100%" justify="center">
               {player.playerType?.title ? (
                 <WrapItem>
@@ -93,9 +87,7 @@ export const PlayerTile: React.FC<Props> = ({ player }) => {
                 </WrapItem>
               )}
               <WrapItem>
-                <MetaTag size="md">{`XP: ${Math.floor(
-                  player.total_xp,
-                )}`}</MetaTag>
+                <MetaTag size="md">XP: {Math.floor(player.total_xp)}</MetaTag>
               </WrapItem>
             </Wrap>
             {tzDisplay?.timeZone ? (
@@ -116,29 +108,29 @@ export const PlayerTile: React.FC<Props> = ({ player }) => {
               </VStack>
             ) : null}
           </MetaTileHeader>
-          <MetaTileBody>
-            {player.Player_Skills.length ? (
-              <VStack spacing={2} align="stretch">
-                <Text textStyle="caption">SKILLS</Text>
-                <SkillsTags
-                  skills={player.Player_Skills.map((s) => s.Skill) as Skill[]}
-                />
-              </VStack>
-            ) : null}
+        </LinkOverlay>
+        <MetaTileBody>
+          {player.Player_Skills.length ? (
+            <VStack spacing={2} align="stretch">
+              <Text textStyle="caption">SKILLS</Text>
+              <SkillsTags
+                skills={player.Player_Skills.map((s) => s.Skill) as Skill[]}
+              />
+            </VStack>
+          ) : null}
 
-            <PlayerTileMemberships player={player} />
+          <PlayerTileMemberships player={player} />
 
-            {player.Accounts.length ? (
-              <VStack spacing={2} align="stretch">
-                <Text textStyle="caption">CONTACT</Text>
-                <HStack mt="2">
-                  <PlayerContacts player={player} disableBrightId />
-                </HStack>
-              </VStack>
-            ) : null}
-          </MetaTileBody>
-        </MetaTile>
-      </LinkOverlay>
+          {player.Accounts.length ? (
+            <VStack spacing={2} align="stretch">
+              <Text textStyle="caption">CONTACT</Text>
+              <HStack mt={2}>
+                <PlayerContacts player={player} disableBrightId />
+              </HStack>
+            </VStack>
+          ) : null}
+        </MetaTileBody>
+      </MetaTile>
     </LinkBox>
   );
 };


### PR DESCRIPTION
We were getting a nested anchor error in development though not in staging. The guess is that it was in some way related to the Next.js build process.

In any case, this PR moves the LinkOverlay on the player tiles so it doesn't encompass the links in the player details. It fixes the error in development.

Paired with: @mquellhorst