### PR TITLE
Fix duplicate MemberOf label in patron tile

### DIFF
--- a/packages/web/components/Patron/PatronTile.tsx
+++ b/packages/web/components/Patron/PatronTile.tsx
@@ -146,12 +146,8 @@ export const PatronTile: React.FC<Props> = ({ index, patron }) => {
             </VStack>
           ) : null}
 
-          {player.daohausMemberships.length ? (
-            <VStack spacing={2} align="stretch">
-              <Text textStyle="caption">MEMBER OF</Text>
-              <PlayerTileMemberships player={player} />
-            </VStack>
-          ) : null}
+          <PlayerTileMemberships player={player} />
+
           {player.Accounts.length ? (
             <VStack spacing={2} align="stretch">
               <Text textStyle="caption">CONTACT</Text>


### PR DESCRIPTION
This was an artifact of the guild-onboarding work