### PR TITLE
Added ability to edit guild form info during onboarding process

### DIFF
--- a/packages/backend/src/handlers/actions/guild/discord/oauthHandler.ts
+++ b/packages/backend/src/handlers/actions/guild/discord/oauthHandler.ts
@@ -54,7 +54,6 @@ export const handleOAuthCallback = async (
         const getGuildResponse = await client.GetGuild({
           id: existingGuild.guild_id,
         });
-
         const successResponse: DiscordGuildAuthResponse = {
           success: true,
           guildname: getGuildResponse.guild[0].guildname,

--- a/packages/backend/src/handlers/graphql/queries.ts
+++ b/packages/backend/src/handlers/graphql/queries.ts
@@ -93,16 +93,8 @@ export const GuildFragment = gql`
 
 // eslint-disable-next-line @typescript-eslint/no-unused-expressions
 gql`
-  query GetGuild($guildname: String, $id: uuid, $discordId: String) {
-    guild(
-      where: {
-        _or: [
-          { id: { _eq: $id } }
-          { guildname: { _eq: $guildname } }
-          { discord_id: { _eq: $discordId } }
-        ]
-      }
-    ) {
+  query GetGuild($id: uuid!) {
+    guild(where: { id: { _eq: $id } }) {
       ...GuildFragment
     }
   }

--- a/packages/web/components/Guild/GuildForm.tsx
+++ b/packages/web/components/Guild/GuildForm.tsx
@@ -115,13 +115,19 @@ export const GuildForm: React.FC<Props> = ({
 }) => {
   const router = useRouter();
 
-  const [getGuildMetadataResponse] = useGetGuildMetadataQuery({
-    variables: { id: workingGuild.id },
-  });
+  const [getGuildMetadataResponse, getGuildMetadata] = useGetGuildMetadataQuery(
+    {
+      variables: { id: workingGuild.id },
+    },
+  );
   const fetchingRoles =
     getGuildMetadataResponse == null || getGuildMetadataResponse.fetching;
   const guildMetadata = getGuildMetadataResponse.data
     ?.guild_metadata[0] as GuildMetadata;
+
+  const loadGuildMetadata = () => {
+    getGuildMetadata({ requestPolicy: 'network-only' });
+  };
 
   const roleOptions = useMemo(() => {
     const allDiscordRoles = guildMetadata?.discordRoles || [];
@@ -152,7 +158,7 @@ export const GuildForm: React.FC<Props> = ({
   }, [workingGuild, guildMetadata, roleOptions, reset]);
 
   return (
-    <Box w="100%" maxW="30rem">
+    <Box w="100%" maxW="40rem">
       <VStack>
         <Field label="Guildname" error={errors.guildname}>
           <Input
@@ -265,7 +271,7 @@ export const GuildForm: React.FC<Props> = ({
             ))}
           </Select>
         </Field>
-        <Box my={10}>
+        <Box py={5}>
           {fetchingRoles ? (
             <div>
               Fetching roles from Discord...
@@ -330,11 +336,20 @@ export const GuildForm: React.FC<Props> = ({
             loadingText="Submitting information..."
             onClick={handleSubmit(onSubmit)}
             isDisabled={success}
+            bg="purple.500"
           >
             Submit guild information
           </MetaButton>
           <MetaButton
-            variant="outline"
+            fontSize="xs"
+            bg="purple.300"
+            colorScheme="facebook"
+            isDisabled={fetchingRoles}
+            onClick={loadGuildMetadata}
+          >
+            Reload roles
+          </MetaButton>
+          <MetaButton
             onClick={() => router.push('/')}
             isDisabled={submitting || success}
           >

--- a/packages/web/components/Guild/GuildForm.tsx
+++ b/packages/web/components/Guild/GuildForm.tsx
@@ -18,7 +18,7 @@ import {
   useGetGuildMetadataQuery,
 } from 'graphql/autogen/types';
 import { useRouter } from 'next/router';
-import React, { useMemo } from 'react';
+import React, { useEffect, useMemo } from 'react';
 import { Controller, useForm } from 'react-hook-form';
 
 const validations = {
@@ -131,20 +131,25 @@ export const GuildForm: React.FC<Props> = ({
     }));
   }, [guildMetadata]);
 
-  const defaultValues = useMemo<EditGuildFormInputs>(
-    () => getDefaultFormValues(workingGuild, guildMetadata, roleOptions),
-    [workingGuild, guildMetadata, roleOptions],
-  );
-
   const {
     register,
     errors,
     handleSubmit,
+    reset,
     control,
   } = useForm<EditGuildFormInputs>({
-    defaultValues,
     mode: 'onTouched',
   });
+
+  useEffect(() => {
+    const values = getDefaultFormValues(
+      workingGuild,
+      guildMetadata,
+      roleOptions,
+    );
+    // https://react-hook-form.com/v6/api#useForm
+    reset(values);
+  }, [workingGuild, guildMetadata, roleOptions, reset]);
 
   return (
     <Box w="100%" maxW="30rem">
@@ -283,10 +288,9 @@ export const GuildForm: React.FC<Props> = ({
                   name="discordAdminRoles"
                   control={control}
                   rules={validations.discordAdminRoles}
-                  defaultValue={defaultValues.discordAdminRoles}
-                  isMulti
-                  options={roleOptions}
-                  as={MultiSelect}
+                  render={(props) => (
+                    <MultiSelect isMulti options={roleOptions} {...props} />
+                  )}
                 />
                 <span>
                   Members of your Discord server with these roles will have
@@ -308,9 +312,9 @@ export const GuildForm: React.FC<Props> = ({
                   name="discordMembershipRoles"
                   control={control}
                   rules={validations.discordMembershipRoles}
-                  isMulti
-                  options={roleOptions}
-                  as={MultiSelect}
+                  render={(props) => (
+                    <MultiSelect isMulti options={roleOptions} {...props} />
+                  )}
                 />
                 <span>
                   Members of your Discord server with these roles will be

--- a/packages/web/pages/join/guild/auth.tsx
+++ b/packages/web/pages/join/guild/auth.tsx
@@ -38,7 +38,7 @@ const GuildSetupAuthCallback: React.FC = () => {
     };
     if (!fetching && code) {
       if (localState == null || localState !== state) {
-        setError('State did not match');
+        setError('State did not match.');
         return;
       }
       setFetching(true);

--- a/packages/web/pages/join/guild/auth.tsx
+++ b/packages/web/pages/join/guild/auth.tsx
@@ -33,11 +33,7 @@ const GuildSetupAuthCallback: React.FC = () => {
       } else if (response?.guildname != null) {
         // clean up guid
         remove(discordAuthStateGuidKey);
-        if (response?.exists === true) {
-          router.push(`/guild/${response?.guildname}`);
-        } else {
-          router.push(`/join/guild/${response?.guildname}`);
-        }
+        router.push(`/join/guild/${response?.guildname}`);
       }
     };
     if (!fetching && code) {


### PR DESCRIPTION
Fixed a couple of issues:

- If you tried to go through the onboarding process a second time (with the same guild), it would erroneously redirect you to another guild page. I fixed the graphql query and it will now redirect you to the `/join/guild/<guildname>` page.
- Fixed initial population of selected discord roles in the two role selection dropdowns.