### PR TITLE
Upgraded docker-compose-wait and bumped the wait timeout to 60

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -17,6 +17,8 @@ services:
       - ${HASURA_PORT}:8080
     environment:
       WAIT_HOSTS: database:5432, ${BACKEND_HOST:-backend:4000}
+      # Backend can take more than 30 seconds to start completely, bump the timeout
+      WAIT_TIMEOUT: 60
       HASURA_GRAPHQL_SERVER_PORT: ${HASURA_PORT:-8080}
       HASURA_GRAPHQL_DATABASE_URL: postgres://${DATABASE_USER}:${DATABASE_PASSWORD}@database:5432/${DATABASE_NAME}
       HASURA_GRAPHQL_ADMIN_SECRET: ${HASURA_GRAPHQL_ADMIN_SECRET}

--- a/hasura/Dockerfile
+++ b/hasura/Dockerfile
@@ -1,6 +1,6 @@
 FROM hasura/graphql-engine:v1.3.3.cli-migrations-v2
 
-ADD https://github.com/ufoscout/docker-compose-wait/releases/download/2.7.3/wait /wait
+ADD https://github.com/ufoscout/docker-compose-wait/releases/download/2.9.0/wait /wait
 RUN chmod +x /wait
 
 ## Default setup


### PR DESCRIPTION
This has annoyed me for a while, often the backend takes like 31 seconds to boot locally..