### PR TITLE
Enable hasura console on previews

### DIFF
--- a/.github/workflows/gcp-deploy.yaml
+++ b/.github/workflows/gcp-deploy.yaml
@@ -88,7 +88,7 @@ jobs:
             --ingress all \
             --allow-unauthenticated \
             --add-cloudsql-instances metagame-thegame:us-east4:thegame \
-            --set-env-vars HASURA_GRAPHQL_DATABASE_URL=postgres://hasura-pr-${{ github.event.number }}:${HASURA_DB_PASSWORD}@/hasura-pr-${{ github.event.number }}?host=/cloudsql/${CLOUDSQL_CONNECTION_NAME},HASURA_GRAPHQL_ADMIN_SECRET=metagame_secret,HASURA_GRAPHQL_SERVER_PORT=8080
+            --set-env-vars HASURA_GRAPHQL_DATABASE_URL=postgres://hasura-pr-${{ github.event.number }}:${HASURA_DB_PASSWORD}@/hasura-pr-${{ github.event.number }}?host=/cloudsql/${CLOUDSQL_CONNECTION_NAME},HASURA_GRAPHQL_ADMIN_SECRET=metagame_secret,HASURA_GRAPHQL_SERVER_PORT=8080,HASURA_GRAPHQL_ENABLE_CONSOLE=true
 
       - name: Build Frontend Container
         uses: mattes/cached-docker-build-action@v1


### PR DESCRIPTION
Alec asked me if I can enable the Hasura console on pull request previews, so here it is!
Clicking on the "Hasura" link in the "Successfully deployed..." message should now open the Hasura console.