### PR TITLE
Add issue templates

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug-report.yaml
+++ b/.github/ISSUE_TEMPLATE/bug-report.yaml
@@ -1,0 +1,42 @@
+name: Bug Report
+description: Report a bug
+body:
+  - type: markdown
+    attributes:
+      value: Thanks for taking the time to fill out this bug report!
+
+  - type: textarea
+    id: problem
+    attributes:
+      label: What happened?
+      description: Please provide as much information as possible.
+    validations:
+      required: true
+
+  - type: textarea
+    id: expected
+    attributes:
+      label: What did you expect to happen?
+    validations:
+      required: true
+
+  - type: textarea
+    id: reproduce
+    attributes:
+      label: How can we reproduce the problem (as minimally as possible)?
+    validations:
+      required: true
+
+  - type: textarea
+    id: additional
+    attributes:
+      label: Is there anything else we need to know?
+    validations:
+      required: false
+
+  - type: textarea
+    id: system-info
+    attributes:
+      label: Browser and operating system used (if applicable)
+    validations:
+      required: false

--- a/.github/ISSUE_TEMPLATE/feature-request.yaml
+++ b/.github/ISSUE_TEMPLATE/feature-request.yaml
@@ -1,0 +1,16 @@
+name: Feature Request
+description: Suggest a new feature
+body:
+  - type: textarea
+    id: feature
+    attributes:
+      label: What would you like to be added?
+    validations:
+      required: true
+
+  - type: textarea
+    id: reason
+    attributes:
+      label: Why is this needed?
+    validations:
+      required: true


### PR DESCRIPTION
This pull request adds two issue templates/forms: bug-report and feature-request
Such issue forms are currently in public beta, but everyone loves some cutting edge tech :D
(Inspired by the [issue templates used by Kubernetes](https://github.com/kubernetes/kubernetes/tree/master/.github/ISSUE_TEMPLATE))