### PR TITLE
add labels to issue templates

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug-report.yaml
+++ b/.github/ISSUE_TEMPLATE/bug-report.yaml
@@ -1,5 +1,6 @@
 name: Bug Report
 description: Report a bug
+labels: ["bug"]
 body:
   - type: markdown
     attributes:

--- a/.github/ISSUE_TEMPLATE/feature-request.yaml
+++ b/.github/ISSUE_TEMPLATE/feature-request.yaml
@@ -1,5 +1,6 @@
 name: Feature Request
 description: Suggest a new feature
+labels: ["feature request"]
 body:
   - type: textarea
     id: feature


### PR DESCRIPTION
as requested by alec: add `bug` and `feature request` labels to their respective issue template