### PR TITLE
Docker image size optimization

### DIFF
--- a/docker/backend/Dockerfile
+++ b/docker/backend/Dockerfile
@@ -34,6 +34,9 @@ COPY packages/@types ./packages/@types/
 # Build
 RUN yarn backend:build
 
+# Delete devDependencies
+RUN yarn install --pure-lockfile --production --ignore-scripts --prefer-offline
+
 # Create completely new stage including only necessary files
 FROM node:14-alpine as app
 WORKDIR /app

--- a/docker/backend/Dockerfile
+++ b/docker/backend/Dockerfile
@@ -1,12 +1,6 @@
 FROM node:14-slim as base
 WORKDIR /usr/src/app
 
-ARG GRAPHQL_HOST
-ARG GRAPHQL_DOMAIN=onrender.com
-
-ENV GRAPHQL_URL https://$GRAPHQL_HOST.$GRAPHQL_DOMAIN/v1/graphql
-ENV HASURA_GRAPHQL_ADMIN_SECRET metagame_secret
-
 # Install dependencies not included in the slim image
 RUN apt-get update && apt-get install -y --no-install-recommends g++ make python
 
@@ -30,6 +24,13 @@ COPY packages/backend ./packages/backend/
 COPY packages/utils ./packages/utils/
 COPY packages/discord-bot ./packages/discord-bot/
 COPY packages/@types ./packages/@types/
+
+# Set env vars
+ARG GRAPHQL_HOST
+ARG GRAPHQL_DOMAIN=onrender.com
+
+ENV GRAPHQL_URL https://$GRAPHQL_HOST.$GRAPHQL_DOMAIN/v1/graphql
+ENV HASURA_GRAPHQL_ADMIN_SECRET metagame_secret
 
 # Build
 RUN yarn backend:build

--- a/docker/backend/Dockerfile
+++ b/docker/backend/Dockerfile
@@ -34,4 +34,22 @@ COPY packages/@types ./packages/@types/
 # Build
 RUN yarn backend:build
 
+# Create completely new stage including only necessary files
+FROM node:14-alpine as app
+WORKDIR /app
+
+# Copy necessary files into the stage
+COPY --from=build /usr/src/app/package.json ./package.json
+COPY --from=build /usr/src/app/node_modules ./node_modules
+
+COPY --from=build /usr/src/app/packages/backend/package.json ./packages/backend/package.json
+COPY --from=build /usr/src/app/packages/backend/dist ./packages/backend/dist
+
+COPY --from=build /usr/src/app/packages/utils/package.json ./packages/utils/package.json
+COPY --from=build /usr/src/app/packages/utils/dist ./packages/utils/dist
+COPY --from=build /usr/src/app/packages/utils/node_modules ./packages/utils/node_modules
+
+COPY --from=build /usr/src/app/packages/discord-bot/package.json ./packages/discord-bot/package.json
+COPY --from=build /usr/src/app/packages/discord-bot/dist ./packages/discord-bot/dist
+
 CMD [ "yarn", "backend", "start" ]

--- a/docker/backend/Dockerfile
+++ b/docker/backend/Dockerfile
@@ -1,4 +1,4 @@
-FROM node:14 as base
+FROM node:14-slim as base
 WORKDIR /usr/src/app
 
 ARG GRAPHQL_HOST
@@ -6,6 +6,9 @@ ARG GRAPHQL_DOMAIN=onrender.com
 
 ENV GRAPHQL_URL https://$GRAPHQL_HOST.$GRAPHQL_DOMAIN/v1/graphql
 ENV HASURA_GRAPHQL_ADMIN_SECRET metagame_secret
+
+# Install dependencies not included in the slim image
+RUN apt-get update && apt-get install -y --no-install-recommends g++ make python
 
 # Install dependencies for dev and prod
 COPY package.json .

--- a/docker/discord-bot/Dockerfile
+++ b/docker/discord-bot/Dockerfile
@@ -1,11 +1,6 @@
 FROM node:12-slim as base
 WORKDIR /usr/src/app
 
-ARG GRAPHQL_HOST
-
-ENV GRAPHQL_URL https://$GRAPHQL_HOST.onrender.com/v1/graphql
-ENV HASURA_GRAPHQL_ADMIN_SECRET metagame_secret
-
 # Install dependencies not included in the slim image
 RUN apt-get update && apt-get install -y --no-install-recommends g++ make python
 
@@ -28,6 +23,13 @@ COPY packages/discord-bot ./packages/discord-bot/
 COPY packages/utils ./packages/utils/
 COPY packages/@types ./packages/@types/
 
+# Set env vars
+ARG GRAPHQL_HOST
+
+ENV GRAPHQL_URL https://$GRAPHQL_HOST.onrender.com/v1/graphql
+ENV HASURA_GRAPHQL_ADMIN_SECRET metagame_secret
+ENV RUNTIME_ENV docker
+
 # Build
 RUN yarn discord-bot build
 
@@ -48,7 +50,5 @@ COPY --from=build /usr/src/app/packages/discord-bot/dist ./packages/discord-bot/
 COPY --from=build /usr/src/app/packages/utils/package.json ./packages/utils/package.json
 COPY --from=build /usr/src/app/packages/utils/dist ./packages/utils/dist
 COPY --from=build /usr/src/app/packages/utils/node_modules ./packages/utils/node_modules
-
-ENV RUNTIME_ENV=docker
 
 CMD [ "yarn", "discord-bot", "start" ]

--- a/docker/discord-bot/Dockerfile
+++ b/docker/discord-bot/Dockerfile
@@ -1,10 +1,13 @@
-FROM node:12 as base
+FROM node:12-slim as base
 WORKDIR /usr/src/app
 
 ARG GRAPHQL_HOST
 
 ENV GRAPHQL_URL https://$GRAPHQL_HOST.onrender.com/v1/graphql
 ENV HASURA_GRAPHQL_ADMIN_SECRET metagame_secret
+
+# Install dependencies not included in the slim image
+RUN apt-get update && apt-get install -y --no-install-recommends g++ make python
 
 # Install dependencies for dev and prod
 COPY package.json .

--- a/docker/discord-bot/Dockerfile
+++ b/docker/discord-bot/Dockerfile
@@ -31,6 +31,9 @@ COPY packages/@types ./packages/@types/
 # Build
 RUN yarn discord-bot build
 
+# Delete devDependencies
+RUN yarn install --pure-lockfile --production --ignore-scripts --prefer-offline
+
 # Create completely new stage including only necessary files
 FROM node:12-alpine as app
 WORKDIR /app

--- a/docker/discord-bot/Dockerfile
+++ b/docker/discord-bot/Dockerfile
@@ -31,6 +31,21 @@ COPY packages/@types ./packages/@types/
 # Build
 RUN yarn discord-bot build
 
+# Create completely new stage including only necessary files
+FROM node:12-alpine as app
+WORKDIR /app
+
+# Copy necessary files into the stage
+COPY --from=build /usr/src/app/package.json ./package.json
+COPY --from=build /usr/src/app/node_modules ./node_modules
+
+COPY --from=build /usr/src/app/packages/discord-bot/package.json ./packages/discord-bot/package.json
+COPY --from=build /usr/src/app/packages/discord-bot/dist ./packages/discord-bot/dist
+
+COPY --from=build /usr/src/app/packages/utils/package.json ./packages/utils/package.json
+COPY --from=build /usr/src/app/packages/utils/dist ./packages/utils/dist
+COPY --from=build /usr/src/app/packages/utils/node_modules ./packages/utils/node_modules
+
 ENV RUNTIME_ENV=docker
 
 CMD [ "yarn", "discord-bot", "start" ]

--- a/docker/frontend/Dockerfile
+++ b/docker/frontend/Dockerfile
@@ -37,4 +37,23 @@ COPY packages/@types ./packages/@types/
 # Build
 RUN yarn web:build
 
+# Create completely new stage including only necessary files
+FROM node:14-alpine as app
+WORKDIR /app
+
+# Copy necessary files into the stage
+COPY --from=build /usr/src/app/package.json ./package.json
+COPY --from=build /usr/src/app/node_modules ./node_modules
+
+COPY --from=build /usr/src/app/packages/web/package.json ./packages/web/package.json
+COPY --from=build /usr/src/app/packages/web/public ./packages/web/public
+COPY --from=build /usr/src/app/packages/web/.next ./packages/web/.next
+
+COPY --from=build /usr/src/app/packages/utils/package.json ./packages/utils/package.json
+COPY --from=build /usr/src/app/packages/utils/dist ./packages/utils/dist
+COPY --from=build /usr/src/app/packages/utils/node_modules ./packages/utils/node_modules
+
+COPY --from=build /usr/src/app/packages/design-system/package.json ./packages/design-system/package.json
+COPY --from=build /usr/src/app/packages/design-system/dist ./packages/design-system/dist
+
 CMD [ "yarn", "web", "start" ]

--- a/docker/frontend/Dockerfile
+++ b/docker/frontend/Dockerfile
@@ -1,11 +1,6 @@
 FROM node:14-slim as base
 WORKDIR /usr/src/app
 
-ARG GRAPHQL_HOST
-ARG GRAPHQL_DOMAIN=onrender.com
-
-ENV NEXT_PUBLIC_GRAPHQL_URL https://$GRAPHQL_HOST.$GRAPHQL_DOMAIN/v1/graphql
-
 # Install dependencies not included in the slim image
 RUN apt-get update && apt-get install -y --no-install-recommends g++ make python git ca-certificates
 
@@ -33,6 +28,12 @@ COPY packages/web ./packages/web/
 COPY packages/utils ./packages/utils/
 COPY packages/design-system ./packages/design-system/
 COPY packages/@types ./packages/@types/
+
+# Set env vars
+ARG GRAPHQL_HOST
+ARG GRAPHQL_DOMAIN=onrender.com
+
+ENV NEXT_PUBLIC_GRAPHQL_URL https://$GRAPHQL_HOST.$GRAPHQL_DOMAIN/v1/graphql
 
 # Build
 RUN yarn web:build

--- a/docker/frontend/Dockerfile
+++ b/docker/frontend/Dockerfile
@@ -1,10 +1,13 @@
-FROM node:14 as base
+FROM node:14-slim as base
 WORKDIR /usr/src/app
 
 ARG GRAPHQL_HOST
 ARG GRAPHQL_DOMAIN=onrender.com
 
 ENV NEXT_PUBLIC_GRAPHQL_URL https://$GRAPHQL_HOST.$GRAPHQL_DOMAIN/v1/graphql
+
+# Install dependencies not included in the slim image
+RUN apt-get update && apt-get install -y --no-install-recommends g++ make python git ca-certificates
 
 # Install dependencies for dev and prod
 COPY package.json .

--- a/docker/frontend/Dockerfile
+++ b/docker/frontend/Dockerfile
@@ -37,6 +37,9 @@ COPY packages/@types ./packages/@types/
 # Build
 RUN yarn web:build
 
+# Delete devDependencies
+RUN yarn install --pure-lockfile --production --ignore-scripts --prefer-offline
+
 # Create completely new stage including only necessary files
 FROM node:14-alpine as app
 WORKDIR /app


### PR DESCRIPTION
Fixes #855 
I have tried to optimize our Dockerfiles since the built images were huge. Sadly couldn't really optimize build time since I'm not experienced enough with yarn etc. and our eventual upgrade to yarn 2 could probably already decrease build time quite a bit.

Some data (single local build per entry, all builds from completely fresh state)
|Name|Old Image Size|New Image Size|Old Build Time|New Build Time|
|---|---|---|---|---|
|frontend|3.2 GB|683 MB|10m13s|10m43s|
|backend|3.11 GB|683 MB|8m35s|6m38s|
|discord-bot|2.08 GB|270 MB|4m17s|4m17s|

-> Overall final image size reductions of ~80% with similar build times

I have only done simple smoke tests with the new images though.