### PR TITLE
Load timezone on client

### DIFF
--- a/packages/web/components/Dashboard/Calendar.tsx
+++ b/packages/web/components/Dashboard/Calendar.tsx
@@ -1,8 +1,16 @@
-import React from 'react';
+import React, { useEffect, useState } from 'react';
 
 const calId = 'nih59ktgafmm64ed4qk6ue8vv4@group.calendar.google.com';
 
 export const Calendar: React.FC = () => {
+  const [isComponentMounted, setIsComponentMounted] = useState(false);
+
+  useEffect(() => setIsComponentMounted(true), []);
+
+  if (!isComponentMounted) {
+    return null;
+  }
+
   const timezone = Intl.DateTimeFormat().resolvedOptions().timeZone;
 
   return (

--- a/packages/web/components/Dashboard/Calendar.tsx
+++ b/packages/web/components/Dashboard/Calendar.tsx
@@ -1,10 +1,9 @@
-import jstz from 'jstz';
 import React from 'react';
 
 const calId = 'nih59ktgafmm64ed4qk6ue8vv4@group.calendar.google.com';
 
 export const Calendar: React.FC = () => {
-  const timezone = jstz.determine().name();
+  const timezone = Intl.DateTimeFormat().resolvedOptions().timeZone;
 
   return (
     <iframe

--- a/packages/web/components/Dashboard/Calendar.tsx
+++ b/packages/web/components/Dashboard/Calendar.tsx
@@ -1,6 +1,5 @@
+import { CONFIG } from 'config';
 import React, { useEffect, useState } from 'react';
-
-const calId = 'nih59ktgafmm64ed4qk6ue8vv4@group.calendar.google.com';
 
 export const Calendar: React.FC = () => {
   const [isComponentMounted, setIsComponentMounted] = useState(false);
@@ -16,7 +15,7 @@ export const Calendar: React.FC = () => {
   return (
     <iframe
       title="calendar"
-      src={`https://calendar.google.com/calendar/embed?height=600&wkst=1&bgcolor=%23ffffff&ctz=${timezone}&showPrint=0&mode=AGENDA&showTitle=0&showNav=1&showTabs=0&showPrint=0&showCalendars=0&src=${calId}&color=%23F09300`}
+      src={`https://calendar.google.com/calendar/embed?height=600&wkst=1&bgcolor=%23ffffff&ctz=${timezone}&showPrint=0&mode=AGENDA&showTitle=0&showNav=1&showTabs=0&showPrint=0&showCalendars=0&src=${CONFIG.calendarId}&color=%23F09300`}
       style={{
         // border: 'solid 1px #777',
         marginTop: 20,

--- a/packages/web/config.ts
+++ b/packages/web/config.ts
@@ -28,7 +28,6 @@ export const CONFIG = {
     process.env.NEXT_CERAMIC_URL ||
     'https://ceramic-clay.3boxlabs.com' || // testnet
     'https://d12-a-ceramic.3boxlabs.com',
-  actionsURL:
-    process.env.NEXT_ACTIONS_URL ||
-    'http://localhost:4000'
+  actionsURL: process.env.NEXT_ACTIONS_URL || 'http://localhost:4000',
+  calendarId: 'nih59ktgafmm64ed4qk6ue8vv4@group.calendar.google.com',
 };

--- a/packages/web/package.json
+++ b/packages/web/package.json
@@ -30,7 +30,6 @@
     "fake-tag": "3.0.0",
     "graphql": "15.5.0",
     "isomorphic-unfetch": "3.1.0",
-    "jstz": "^2.1.1",
     "moment": "2.29.1",
     "next": "10.2.3",
     "next-images": "1.7.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -19780,11 +19780,6 @@ jss@10.6.0, jss@^10.5.1:
     is-in-browser "^1.1.3"
     tiny-warning "^1.0.2"
 
-jstz@^2.1.1:
-  version "2.1.1"
-  resolved "https://registry.yarnpkg.com/jstz/-/jstz-2.1.1.tgz#fff3373a518fa7cce69299930466f5a2b980389d"
-  integrity sha512-8hfl5RD6P7rEeIbzStBz3h4f+BQHfq/ABtoU6gXKQv5OcZhnmrIpG7e1pYaZ8hS9e0mp+bxUj08fnDUbKctYyA==
-
 "jsx-ast-utils@^2.4.1 || ^3.0.0", jsx-ast-utils@^3.1.0:
   version "3.2.0"
   resolved "https://registry.yarnpkg.com/jsx-ast-utils/-/jsx-ast-utils-3.2.0.tgz#41108d2cec408c3453c1bbe8a4aae9e1e2bd8f82"


### PR DESCRIPTION
## Overview

**What features/fixes does this PR include?**

Displaying dashboard calendar in the timezone of the user that's currently viewing it.
Remove the `jstz` library and use Intl to get the timezone name. The coverage of Intl is 94% - should we proceed with using it or should we go for a more universal package for figuring out the timezone? https://caniuse.com/?search=Intl

## Implementation

Set up a hook that's the equivalent of componentDidMount and execute the setting of timezone on client.
