### PR TITLE
Implement `addAlias` in discord-bot

### DIFF
--- a/packages/@types/sourcecred/index.d.ts
+++ b/packages/@types/sourcecred/index.d.ts
@@ -788,8 +788,13 @@ declare module 'sourcecred' {
     accounts: () => SCAccountInfo[];
     account: (id: string) => SCAccountInfo;
     accountByAddress: (address: string) => SCAccountInfo;
-    addAlias: (identityId: any, alias: any) => void;
+    addAlias: (identityId: any, alias: Alias) => void;
     activate: (identityId: any) => void;
+  }
+
+  export interface Alias {
+    description: string;
+    address: string;
   }
 
   export interface ReloadResult {

--- a/packages/discord-bot/src/config.ts
+++ b/packages/discord-bot/src/config.ts
@@ -11,6 +11,7 @@ interface IConfig {
   discordBotClientSecret: string;
   sourceCredLedgerBranch: string;
   discordApiBaseUrl: string;
+  discourseInstanceUrl: string;
 }
 
 function parseEnv<T extends string | number>(
@@ -51,5 +52,9 @@ export const CONFIG: IConfig = {
   discordApiBaseUrl: parseEnv(
     process.env.DISCORD_API_BASE_URL,
     'https://discord.com/api/v8',
+  ),
+  discourseInstanceUrl: parseEnv(
+    process.env.DISCOURSE_INSTANCE_URL,
+    'https://forum.metagame.wtf',
   ),
 };

--- a/packages/discord-bot/src/discord/commands/addAlias.ts
+++ b/packages/discord-bot/src/discord/commands/addAlias.ts
@@ -1,0 +1,160 @@
+import { Command, CommandMessage } from '@typeit/discord';
+import { Alias, sourcecred as sc } from 'sourcecred';
+
+import { CONFIG } from '../../config';
+import { loadSourceCredLedger, resetLedger } from '../../sourcecred';
+
+const supportedPlatforms = ['github', 'discourse'];
+const errorSupportedPlatforms = `Supported platforms: ${supportedPlatforms.join(
+  ', ',
+)}`;
+
+type AddAliasArgs = {
+  platform: string;
+  id: string;
+};
+
+export class AddAlias {
+  @Command('!addAlias :platform :id')
+  async addAlias(message: CommandMessage<AddAliasArgs>) {
+    const res = await loadSourceCredLedger();
+    const { result: reloadResult, manager } = res;
+
+    if (reloadResult.error) {
+      await message.reply(`Error Loading Ledger: ${reloadResult.error}`);
+      return;
+    }
+
+    if (!message.args.id || !message.args.platform) {
+      await message.reply(
+        `Usage: addAlias <platform> <id>. ${errorSupportedPlatforms}`,
+      );
+      return;
+    }
+
+    let alias: Alias;
+    let sanitizedId: string;
+
+    // parse and validate platform arg
+    const trimmedPlatform = message.args.platform.trim().toLowerCase();
+
+    if (trimmedPlatform === 'github') {
+      // standardize and sanitize input
+      sanitizedId = message.args.id
+        .trim()
+        .toLowerCase()
+        // Sanitize: Github allows alphanumeric characters plus -
+        .replace(/[^0-9a-z-]/, '');
+      const rawAddress = sc.plugins.github.nodes.loginAddress(sanitizedId);
+
+      alias = {
+        // Ideally, we can use the SourceCred API to generate this description, but it's
+        // not currently exposed in a useful way for this use case
+        description: `github/[@${sanitizedId}](https://github.com/${sanitizedId})`,
+        address: rawAddress,
+      };
+    } else if (trimmedPlatform === 'discourse') {
+      sanitizedId = message.args.id
+        .trim()
+        // Sanitize: Discourse allows alphanumeric characters plus -_.
+        .replace(/[^0-9a-zA-Z-_.]/, '');
+      const rawAddress = sc.plugins.discourse.address.userAddress(
+        CONFIG.discourseInstanceUrl,
+        sanitizedId,
+      );
+      alias = {
+        // Ideally, we can use the SourceCred API to generate this description, but it's
+        // not currently exposed in a useful way for this use case
+        description: `discourse/[@${sanitizedId}](${CONFIG.discourseInstanceUrl}/u/${sanitizedId}/)`,
+        address: rawAddress,
+      };
+    } else {
+      await message.reply(`Invalid platform. ${errorSupportedPlatforms}`);
+      return;
+    }
+
+    try {
+      // we need to make sure this discord user already exists in the ledger.
+      const baseIdentityProposal = sc.plugins.discord.utils.identity.createIdentity(
+        message.member,
+      );
+      const existingIdentity = manager.ledger.accountByAddress(
+        baseIdentityProposal.alias.address,
+      );
+      // Fail if no account exists yet for this discord user
+      if (!existingIdentity) {
+        await message.reply(
+          'Could not find an identity linked to your user. Please use the !setAddress command first.',
+        );
+        return;
+      }
+
+      // ensure that this user has not already added an alias for this platform
+      const addressModule = sc.core.address.makeAddressModule({
+        name: 'NodeAddress',
+        nonce: 'N',
+      });
+      const platformAlias = existingIdentity.identity.aliases.find(
+        (existingAlias) => {
+          const parts = addressModule.toParts(existingAlias.address);
+          return parts[1] === trimmedPlatform;
+        },
+      );
+      if (platformAlias != null) {
+        const parts = addressModule.toParts(platformAlias.address);
+        const existingPlatformIdentifier = parts[parts.length - 1];
+        if (sanitizedId === existingPlatformIdentifier) {
+          await message.reply('You have already linked this account!');
+        } else {
+          await message.reply(
+            `You have already linked a ${trimmedPlatform} account: ${
+              parts[parts.length - 1]
+            }`,
+          );
+        }
+        return;
+      }
+
+      // ensure nobody else is already using this alias
+      const linkedAccount = manager.ledger.accountByAddress(alias.address);
+
+      if (linkedAccount) {
+        await message.reply(
+          `This account is already linked to ${linkedAccount.identity.name}.`,
+        );
+        return;
+      }
+
+      manager.ledger.addAlias(existingIdentity.identity.id, alias);
+      const persistRes = await manager.persist();
+
+      if (persistRes.error) {
+        await message.reply(
+          `Error Updating Ledger: ${
+            persistRes.error
+          }.\n\n ${persistRes.localChanges
+            // eslint-disable-next-line @typescript-eslint/no-explicit-any
+            .map((c: any) => JSON.stringify(c.action))
+            .join('\n')}`,
+        );
+        // eslint-disable-next-line @typescript-eslint/no-explicit-any
+        persistRes.localChanges.forEach((change: any) => {
+          console.error(change.action);
+        });
+
+        // ledger may be in a bad state, throw away these local changes
+        resetLedger();
+        return;
+      }
+
+      await message.reply(
+        `Successfully added ${trimmedPlatform} alias: '${sanitizedId}'`,
+      );
+    } catch (e) {
+      await message.reply(
+        'MetaGameBot regrets to inform you of an unexpected error 😥. Contact a friendly Builder for assistance.',
+      );
+      console.error(e);
+    }
+  }
+}

--- a/packages/discord-bot/src/discord/commands/addAlias.ts
+++ b/packages/discord-bot/src/discord/commands/addAlias.ts
@@ -7,7 +7,7 @@ import { loadSourceCredLedger, resetLedger } from '../../sourcecred';
 const supportedPlatforms = ['github', 'discourse'];
 const errorSupportedPlatforms = `Supported platforms: ${supportedPlatforms.join(
   ', ',
-)}`;
+)}.`;
 
 type AddAliasArgs = {
   platform: string;
@@ -27,7 +27,7 @@ export class AddAlias {
 
     if (!message.args.id || !message.args.platform) {
       await message.reply(
-        `Usage: addAlias <platform> <id>. ${errorSupportedPlatforms}`,
+        `Usage: addAlias <platform> <id>.\n\n${errorSupportedPlatforms}`,
       );
       return;
     }
@@ -69,7 +69,7 @@ export class AddAlias {
         address: rawAddress,
       };
     } else {
-      await message.reply(`Invalid platform. ${errorSupportedPlatforms}`);
+      await message.reply(`Invalid platform.\n\n${errorSupportedPlatforms}`);
       return;
     }
 
@@ -107,9 +107,7 @@ export class AddAlias {
           await message.reply('You have already linked this account!');
         } else {
           await message.reply(
-            `You have already linked a ${trimmedPlatform} account: ${
-              parts[parts.length - 1]
-            }`,
+            `You have already linked a ${trimmedPlatform} account: ${existingPlatformIdentifier}.`,
           );
         }
         return;
@@ -148,7 +146,7 @@ export class AddAlias {
       }
 
       await message.reply(
-        `Successfully added ${trimmedPlatform} alias: '${sanitizedId}'`,
+        `Successfully added ${trimmedPlatform} alias: ${sanitizedId}.`,
       );
     } catch (e) {
       await message.reply(

--- a/packages/discord-bot/src/discord/commands/setEthAddress.ts
+++ b/packages/discord-bot/src/discord/commands/setEthAddress.ts
@@ -74,7 +74,8 @@ To force update your address, type \`!setAddress ${ethAddress} force\`.
 
     try {
       manager.ledger.addAlias(baseIdentityId, ethAlias);
-      manager.ledger.activate(baseIdentityId);
+      // don't activate yet; only Players should be able to receive SEEDs
+      // and they must be manually activated at mint-time
       const persistRes = await manager.persist();
 
       if (persistRes.error) {

--- a/packages/discord-bot/src/discord/commands/setEthAddress.ts
+++ b/packages/discord-bot/src/discord/commands/setEthAddress.ts
@@ -1,7 +1,7 @@
 import { Command, CommandMessage } from '@typeit/discord';
 import { sourcecred as sc } from 'sourcecred';
 
-import { loadSourceCredLedger, manager } from '../../sourcecred';
+import { loadSourceCredLedger } from '../../sourcecred';
 
 const addressUtils = sc.plugins.ethereum.utils.address;
 
@@ -14,9 +14,10 @@ export abstract class SetEthAddress {
   @Command('!setAddress :ethAddress :force')
   async setAddress(message: CommandMessage<SetEthAddressArgs>) {
     const res = await loadSourceCredLedger();
+    const { result: reloadResult, manager } = res;
 
-    if (res.error) {
-      await message.reply(`Error Loading Ledger: ${res.error}`);
+    if (reloadResult.error) {
+      await message.reply(`Error Loading Ledger: ${reloadResult.error}`);
       return;
     }
 


### PR DESCRIPTION
## Overview

**What features/fixes does this PR include?**

The old sourcecred [bot](https://github.com/MetaFam/bot) is still handling the `addAlias` command, but it's updating the wrong ledger, so players *think* they are linking these accounts, but are actually not. We have to go through each of these (for players) manually at mint-time and add them.

This is also a much cleaner implementation that uses the sourcecred API rather than writing to ancillary files in GitHub like the old bot did.

Closes #20

## Implementation

**Describe technical (nontrivial / non-obvious) parts of your code**

There is a fair amount of reliance on sourcecred internals. The ideal way of going about this would be to add additional API methods to sourcecred to make certain things easier (such as building the alias description).

**Side effects**

The old bot should be disabled when this goes live.
