### PR TITLE
fix: dao memberships without title are also displayed

### DIFF
--- a/packages/web/components/Player/PlayerGuild.tsx
+++ b/packages/web/components/Player/PlayerGuild.tsx
@@ -1,0 +1,80 @@
+import { Link } from '@metafam/ds';
+import React from 'react';
+
+import polygonImage from '../../assets/chains/polygon.png';
+import xDaiImage from '../../assets/chains/xDai.png';
+import ethereumImage from '../../assets/moloch/ethereum.png';
+import hausdaoImage from '../../assets/moloch/hausdao.png';
+import metacartelImage from '../../assets/moloch/metacartel.png';
+import metaclanImage from '../../assets/moloch/metaclan.png';
+import raidGuildImage from '../../assets/moloch/raid_guild.png';
+
+type LinkGuildProps = {
+  daoUrl: string;
+  guildname: string | undefined;
+};
+
+const getHexChainId = (chain: string | undefined): string => {
+  switch (chain?.toLowerCase()) {
+    case 'xdai':
+      return '0x64';
+    case 'ethereum':
+      return '0x1';
+    case 'polygon':
+      return '0x89';
+    default:
+      return '';
+  }
+};
+
+export const getImageMoloch = (title: string): File => {
+  if (title.toLowerCase().includes('hausdao')) return hausdaoImage;
+  if (title.toLowerCase().includes('metacartel')) return metacartelImage;
+  if (title.toLowerCase().includes('metaclan')) return metaclanImage;
+  if (title.toLowerCase().includes('raid guild')) return raidGuildImage;
+  if (title.toLowerCase().includes('xdai')) return xDaiImage;
+  if (title.toLowerCase().includes('polygon')) return polygonImage;
+  return ethereumImage;
+};
+
+export const getDaoLink = (
+  chain: string | undefined,
+  address: string | undefined,
+): string => {
+  const hexChainId = getHexChainId(chain);
+  if (address && hexChainId) {
+    return `https://app.daohaus.club/dao/${hexChainId}/${address.toLowerCase()}`;
+  }
+  return '';
+};
+
+export const LinkGuild: React.FC<LinkGuildProps> = ({
+  daoUrl,
+  guildname,
+  children,
+}) => {
+  if (guildname != null) {
+    return (
+      <Link
+        role="group"
+        _hover={{ textDecoration: 'none' }}
+        href={`/guild/${guildname}`}
+      >
+        {children}
+      </Link>
+    );
+  }
+  if (daoUrl != null) {
+    return (
+      <Link
+        role="group"
+        _hover={{ textDecoration: 'none' }}
+        href={daoUrl}
+        isExternal
+      >
+        {children}
+      </Link>
+    );
+  }
+  return <>{children}</>;
+};

--- a/packages/web/components/Player/Section/PlayerMemberships.tsx
+++ b/packages/web/components/Player/Section/PlayerMemberships.tsx
@@ -27,7 +27,7 @@ import metaclanImage from '../../../assets/moloch/metaclan.png';
 import raidGuildImage from '../../../assets/moloch/raid_guild.png';
 import { ProfileSection } from '../../ProfileSection';
 
-const getImageMoloch = (title: string) => {
+export const getImageMoloch = (title: string): File => {
   if (title.toLowerCase().includes('hausdao')) return hausdaoImage;
   if (title.toLowerCase().includes('metacartel')) return metacartelImage;
   if (title.toLowerCase().includes('metaclan')) return metaclanImage;
@@ -50,7 +50,7 @@ const getHexChainId = (chain: string | undefined): string => {
   }
 };
 
-const getDaoLink = (
+export const getDaoLink = (
   chain: string | undefined,
   address: string | undefined,
 ): string => {
@@ -66,7 +66,7 @@ type LinkGuildProps = {
   guildname: string | undefined;
 };
 
-const LinkGuild: React.FC<LinkGuildProps> = ({
+export const LinkGuild: React.FC<LinkGuildProps> = ({
   daoUrl,
   guildname,
   children,

--- a/packages/web/components/Player/Section/PlayerMemberships.tsx
+++ b/packages/web/components/Player/Section/PlayerMemberships.tsx
@@ -3,7 +3,6 @@ import {
   Flex,
   Heading,
   HStack,
-  Link,
   LoadingState,
   Modal,
   ModalCloseButton,
@@ -18,84 +17,8 @@ import { getAllMemberships, GuildMembership } from 'graphql/getMemberships';
 import React, { useEffect, useMemo, useState } from 'react';
 import { isBackdropFilterSupported } from 'utils/compatibilityHelpers';
 
-import polygonImage from '../../../assets/chains/polygon.png';
-import xDaiImage from '../../../assets/chains/xDai.png';
-import ethereumImage from '../../../assets/moloch/ethereum.png';
-import hausdaoImage from '../../../assets/moloch/hausdao.png';
-import metacartelImage from '../../../assets/moloch/metacartel.png';
-import metaclanImage from '../../../assets/moloch/metaclan.png';
-import raidGuildImage from '../../../assets/moloch/raid_guild.png';
 import { ProfileSection } from '../../ProfileSection';
-
-export const getImageMoloch = (title: string): File => {
-  if (title.toLowerCase().includes('hausdao')) return hausdaoImage;
-  if (title.toLowerCase().includes('metacartel')) return metacartelImage;
-  if (title.toLowerCase().includes('metaclan')) return metaclanImage;
-  if (title.toLowerCase().includes('raid guild')) return raidGuildImage;
-  if (title.toLowerCase().includes('xdai')) return xDaiImage;
-  if (title.toLowerCase().includes('polygon')) return polygonImage;
-  return ethereumImage;
-};
-
-const getHexChainId = (chain: string | undefined): string => {
-  switch (chain?.toLowerCase()) {
-    case 'xdai':
-      return '0x64';
-    case 'ethereum':
-      return '0x1';
-    case 'polygon':
-      return '0x89';
-    default:
-      return '';
-  }
-};
-
-export const getDaoLink = (
-  chain: string | undefined,
-  address: string | undefined,
-): string => {
-  const hexChainId = getHexChainId(chain);
-  if (address && hexChainId) {
-    return `https://app.daohaus.club/dao/${hexChainId}/${address.toLowerCase()}`;
-  }
-  return '';
-};
-
-type LinkGuildProps = {
-  daoUrl: string;
-  guildname: string | undefined;
-};
-
-export const LinkGuild: React.FC<LinkGuildProps> = ({
-  daoUrl,
-  guildname,
-  children,
-}) => {
-  if (guildname != null) {
-    return (
-      <Link
-        role="group"
-        _hover={{ textDecoration: 'none' }}
-        href={`/guild/${guildname}`}
-      >
-        {children}
-      </Link>
-    );
-  }
-  if (daoUrl != null) {
-    return (
-      <Link
-        role="group"
-        _hover={{ textDecoration: 'none' }}
-        href={daoUrl}
-        isExternal
-      >
-        {children}
-      </Link>
-    );
-  }
-  return <>{children}</>;
-};
+import { getDaoLink, getImageMoloch, LinkGuild } from '../PlayerGuild';
 
 type DaoListingProps = {
   membership: GuildMembership;

--- a/packages/web/components/Setup/SetupMemberships.tsx
+++ b/packages/web/components/Setup/SetupMemberships.tsx
@@ -14,11 +14,7 @@ import { Membership } from 'graphql/types';
 import React, { useState } from 'react';
 
 import { useWeb3 } from '../../lib/hooks';
-import {
-  getDaoLink,
-  getImageMoloch,
-  LinkGuild,
-} from '../Player/Section/PlayerMemberships';
+import { getDaoLink, getImageMoloch, LinkGuild } from '../Player/PlayerGuild';
 
 export type SetupMembershipsProps = {
   memberships: Array<Membership> | null | undefined;

--- a/packages/web/components/Setup/SetupMemberships.tsx
+++ b/packages/web/components/Setup/SetupMemberships.tsx
@@ -1,10 +1,12 @@
 import {
+  Box,
+  Flex,
+  Heading,
+  HStack,
   MetaButton,
   MetaHeading,
-  MetaTag,
   Text,
   Wrap,
-  WrapItem,
 } from '@metafam/ds';
 import { FlexContainer } from 'components/Container';
 import { useSetupFlow } from 'contexts/SetupContext';
@@ -12,6 +14,11 @@ import { Membership } from 'graphql/types';
 import React, { useState } from 'react';
 
 import { useWeb3 } from '../../lib/hooks';
+import {
+  getDaoLink,
+  getImageMoloch,
+  LinkGuild,
+} from '../Player/Section/PlayerMemberships';
 
 export type SetupMembershipsProps = {
   memberships: Array<Membership> | null | undefined;
@@ -52,11 +59,7 @@ export const SetupMemberships: React.FC<SetupMembershipsProps> = ({
             </Text>
             <Wrap justify="center" mb={10} spacing={4} maxW="50rem">
               {memberships.map((member) => (
-                <WrapItem key={member.id}>
-                  <MetaTag size="lg" fontWeight="normal">
-                    {member.moloch.title}
-                  </MetaTag>
-                </WrapItem>
+                <MembershipListing key={member.id} member={member} />
               ))}
             </Wrap>
           </>
@@ -76,5 +79,45 @@ export const SetupMemberships: React.FC<SetupMembershipsProps> = ({
         {nextButtonLabel}
       </MetaButton>
     </FlexContainer>
+  );
+};
+
+type MembershipListingProps = {
+  member: Membership;
+};
+
+const MembershipListing: React.FC<MembershipListingProps> = ({ member }) => {
+  const guildLogo = getImageMoloch(member.moloch.title || member.moloch.chain);
+  const daoUrl = getDaoLink(member.moloch.chain, member.moloch.id);
+
+  return (
+    <LinkGuild
+      daoUrl={daoUrl}
+      guildname={member.moloch.title as string | undefined}
+    >
+      <HStack alignItems="center" mb={4}>
+        <Flex bg="purpleBoxLight" width={16} height={16} mr={6}>
+          <Box
+            bgImage={`url(${guildLogo})`}
+            backgroundSize="cover"
+            width={12}
+            height={12}
+            m="auto"
+          />
+        </Flex>
+        <Box>
+          <Heading
+            _groupHover={{ textDecoration: 'underline' }}
+            fontWeight="bold"
+            textTransform="uppercase"
+            fontSize="xs"
+            color={daoUrl ? 'cyanText' : 'white'}
+            mb="1"
+          >
+            {member.moloch.title || `Unknown ${member.moloch.chain} DAO`}
+          </Heading>
+        </Box>
+      </HStack>
+    </LinkGuild>
   );
 };


### PR DESCRIPTION
## Overview

Closes #863 

## Implementation

Made all DAO membership display properly on the `/profile/setup`.
Also added Image and Url link of the dao

Note: this change won't be visible on the deployed website. you would first have to allow this page to show.
For that you would have to go to `web/lib/hooks/index`  and comment some things

## Assets

<img width="1440" alt="Screenshot 2021-11-20 at 5 36 20 PM" src="https://user-images.githubusercontent.com/53316345/142725691-197c9b8d-31c8-43ca-85cf-1cefffa2445f.png">

