### PR TITLE
Show all players, even those that haven't created a profile

### DIFF
--- a/packages/web/components/Player/Filter/AdjacentTimezonePlayers.tsx
+++ b/packages/web/components/Player/Filter/AdjacentTimezonePlayers.tsx
@@ -1,6 +1,6 @@
 import { Flex, Skeleton, Text, TimezoneOptions, VStack } from '@metafam/ds';
 import { PlayerList } from 'components/Player/PlayerList';
-import { GetPlayersQueryVariables } from 'graphql/autogen/types';
+import { PlayersQueryVariables } from 'graphql/getPlayers';
 import { usePlayerFilter } from 'lib/hooks/players';
 import { useOnScreen } from 'lib/hooks/useOnScreen';
 import React, { useEffect, useMemo, useRef, useState } from 'react';
@@ -8,11 +8,11 @@ import React, { useEffect, useMemo, useRef, useState } from 'react';
 import { PlayersLoading } from './PlayersLoading';
 
 const getAdjacentTimezoneQueryVariables = (
-  defaultQueryVariables: GetPlayersQueryVariables,
-): GetPlayersQueryVariables => {
+  defaultQueryVariables: PlayersQueryVariables,
+): PlayersQueryVariables => {
   const timezoneValue = defaultQueryVariables.timezones?.[0];
   const timezone = TimezoneOptions.find((t) => t.value === timezoneValue);
-  const adjascentTimezones = timezone
+  const adjacentTimezones = timezone
     ? TimezoneOptions.filter(
         (t) =>
           Math.abs(t.offset - timezone.offset) <= 4 &&
@@ -22,20 +22,20 @@ const getAdjacentTimezoneQueryVariables = (
   return {
     ...defaultQueryVariables,
     offset: 0,
-    timezones: adjascentTimezones,
+    timezones: adjacentTimezones,
   };
 };
 
 type Props = {
-  queryVariables: GetPlayersQueryVariables;
+  queryVariables: PlayersQueryVariables;
   showSeasonalXP?: boolean;
 };
 
-export const AdjascentTimezonePlayers: React.FC<Props> = ({
+export const AdjacentTimezonePlayers: React.FC<Props> = ({
   queryVariables,
   showSeasonalXP,
 }) => {
-  const [variables, setVariables] = useState<GetPlayersQueryVariables>(
+  const [variables, setVariables] = useState<PlayersQueryVariables>(
     getAdjacentTimezoneQueryVariables(queryVariables),
   );
 

--- a/packages/web/components/Player/Filter/PlayerFilter.tsx
+++ b/packages/web/components/Player/Filter/PlayerFilter.tsx
@@ -19,7 +19,7 @@ import {
 } from '@metafam/ds';
 import { DesktopFilters } from 'components/Player/Filter/DesktopFilters';
 import { MobileFilters } from 'components/Player/Filter/MobileFilters';
-import { GetPlayersQueryVariables } from 'graphql/autogen/types';
+import { PlayersQueryVariables } from 'graphql/getPlayers';
 import {
   PlayerAggregates,
   QueryVariableSetter,
@@ -43,7 +43,7 @@ type Props = {
   fetching: boolean;
   fetchingMore: boolean;
   aggregates: PlayerAggregates;
-  queryVariables: GetPlayersQueryVariables;
+  queryVariables: PlayersQueryVariables;
   setQueryVariable: QueryVariableSetter;
   resetFilter: () => void;
   totalCount: number;
@@ -118,7 +118,7 @@ export const PlayerFilter: React.FC<Props> = ({
   useEffect(() => {
     setQueryVariable(
       'availability',
-      availability ? parseInt(availability.value, 10) : 0,
+      availability ? parseInt(availability.value, 10) : null,
     );
   }, [setQueryVariable, availability]);
 

--- a/packages/web/components/Player/Section/PlayerHero.tsx
+++ b/packages/web/components/Player/Section/PlayerHero.tsx
@@ -23,7 +23,7 @@ import { useUser } from 'lib/hooks';
 import React, { useEffect, useState } from 'react';
 import { FaClock, FaGlobe } from 'react-icons/fa';
 import { getPlayerTimeZoneDisplay } from 'utils/dateHelpers';
-import { getPlayerDescription } from 'utils/playerHelpers';
+import { getPlayerDescription, getPlayerName } from 'utils/playerHelpers';
 
 import { ProfileSection } from '../../ProfileSection';
 import { PlayerContacts } from '../PlayerContacts';
@@ -60,7 +60,7 @@ export const PlayerHero: React.FC<Props> = ({ player, isOwnProfile }) => {
 
       setAvailabilityHours(person.availability_hours || 0);
       setPronouns(person.pronouns || '');
-      setPlayerName(person.username);
+      setPlayerName(getPlayerName(person));
     }
   }, [user, player, isOwnProfile]);
 

--- a/packages/web/pages/players.tsx
+++ b/packages/web/pages/players.tsx
@@ -1,14 +1,17 @@
 import { Text, VStack } from '@metafam/ds';
 import { PageContainer } from 'components/Container';
-import { AdjascentTimezonePlayers } from 'components/Player/Filter/AdjascentTimezonePlayers';
+import { AdjacentTimezonePlayers } from 'components/Player/Filter/AdjacentTimezonePlayers';
 import { PlayerFilter } from 'components/Player/Filter/PlayerFilter';
 import { PlayersLoading } from 'components/Player/Filter/PlayersLoading';
 import { PlayersNotFound } from 'components/Player/Filter/PlayersNotFound';
 import { PlayerList } from 'components/Player/PlayerList';
 import { HeadComponent } from 'components/Seo';
-import { GetPlayersQueryVariables } from 'graphql/autogen/types';
 import { getSsrClient } from 'graphql/client';
-import { getPlayerFilters, getPlayersWithCount } from 'graphql/getPlayers';
+import {
+  getPlayerFilters,
+  getPlayersWithCount,
+  PlayersQueryVariables,
+} from 'graphql/getPlayers';
 import { usePlayerFilter } from 'lib/hooks/players';
 import { useOnScreen } from 'lib/hooks/useOnScreen';
 import { InferGetStaticPropsType } from 'next';
@@ -109,7 +112,7 @@ export default Players;
 type MorePlayersProps = {
   fetching: boolean;
   totalCount: number;
-  queryVariables: GetPlayersQueryVariables;
+  queryVariables: PlayersQueryVariables;
   showSeasonalXP?: boolean;
 };
 
@@ -128,7 +131,7 @@ const MorePlayers = React.forwardRef<HTMLDivElement, MorePlayersProps>(
         ) : null}
         {!fetching && totalCount === 0 ? <PlayersNotFound /> : null}
         {!fetching && isTimezoneSelected ? (
-          <AdjascentTimezonePlayers
+          <AdjacentTimezonePlayers
             queryVariables={queryVariables}
             showSeasonalXP={showSeasonalXP}
           />


### PR DESCRIPTION
## Overview

**What features/fixes does this PR include?**

When the players filter was implemented, it inadvertently starting filtering out any players that hadn't set up a profile, or more specifically, any player without any skills set.

I also fixed the display of a player's name in the PlayerHero component to match that of the PlayerTile.

**Please provide the GitHub issue number**

Closes #739

## Follow up Improvement Ideas

Need to test to see if this also resolves #839 as well

## Implementation

**Describe technical (nontrivial / non-obvious) parts of your code**

The graphql query was refactored to take the entire where clause as a variable, rather than just the filter variables.
