### PR TITLE
Added !mg prefix to discord-bot commands, added help section

### DIFF
--- a/packages/discord-bot/src/discord/commands/addAlias.ts
+++ b/packages/discord-bot/src/discord/commands/addAlias.ts
@@ -15,7 +15,7 @@ type AddAliasArgs = {
 };
 
 export class AddAlias {
-  @Command('!addAlias :platform :id')
+  @Command('!mg addAlias :platform :id')
   async addAlias(message: CommandMessage<AddAliasArgs>) {
     const res = await loadSourceCredLedger();
     const { result: reloadResult, manager } = res;

--- a/packages/discord-bot/src/discord/commands/getXp.ts
+++ b/packages/discord-bot/src/discord/commands/getXp.ts
@@ -12,7 +12,7 @@ import {
 import { getDiscordId, replyWithUnexpectedError } from '../../utils';
 
 export class GetXpCommand {
-  @Command('!xp :discordUser')
+  @Command('!mg xp :discordUser')
   async getXp(message: CommandMessage) {
     let targetUserDiscordId = '';
     try {

--- a/packages/discord-bot/src/discord/commands/help.ts
+++ b/packages/discord-bot/src/discord/commands/help.ts
@@ -1,0 +1,20 @@
+import { Command, CommandMessage } from '@typeit/discord';
+
+const helpContent = `
+Available MetaGameBot commands:
+
+- !mg setAddress [force] → Links your Discord account with the provided Ethereum address. Appending _force_ to the end signifies that you'd like to overwrite an existing account. Note that MyMeta (and 3box) profiles are tied to a given ethereum address, so if you replace it you'll have to create a new MyMeta (and 3box) profile.
+
+- !mg addAlias <platform> <username> → Links your Discord account with the given identifier on the given platform, so that activities by this user can earn you XP. Supported platforms: github, discourse.  Note that Discord will be linked to your username automatically.
+
+- !mg xp [@discordUser#1223] → Displays XP stats for the given Discord user. If no user is provided, _your_ xp is displayed.
+
+- !mg help → This command.
+`;
+
+export class HelpCommand {
+  @Command('!mg help')
+  async getXp(message: CommandMessage) {
+    await message.reply(helpContent);
+  }
+}

--- a/packages/discord-bot/src/discord/commands/setEthAddress.ts
+++ b/packages/discord-bot/src/discord/commands/setEthAddress.ts
@@ -11,7 +11,7 @@ type SetEthAddressArgs = {
 };
 
 export abstract class SetEthAddress {
-  @Command('!setAddress :ethAddress :force')
+  @Command('!mg setAddress :ethAddress :force')
   async setAddress(message: CommandMessage<SetEthAddressArgs>) {
     const res = await loadSourceCredLedger();
     const { result: reloadResult, manager } = res;


### PR DESCRIPTION
## Overview

**What features/fixes does this PR include?**

Our bot used the !ac prefix which is tied to sourcecred. We should be using our own prefix to uniquely associate commands to our `MetaGameBot`. 

Also, I ported the `help` implementation over to this repo so that all commands are handled by the same codebase.  

After this gets promoted to prod, we should disable the old bot completely.
