### PR TITLE
feat/ add 404 redirection for nested routes

### DIFF
--- a/packages/web/pages/404.tsx
+++ b/packages/web/pages/404.tsx
@@ -7,8 +7,11 @@ import Link from 'next/link';
 import { useRouter } from 'next/router';
 import React, { FC } from 'react';
 
+import { useWeb3 } from '../lib/hooks';
+
 const Custom404: FC = () => {
   const router = useRouter();
+  const { connected } = useWeb3();
 
   return (
     <Flex>
@@ -83,7 +86,9 @@ const Custom404: FC = () => {
           <Box pt={5}>
             <MetaSecondaryButton
               width={{ base: '100%', md: '50%', lg: '25%', xl: '25%' }}
-              onClick={() => router.push('/')}
+              onClick={() =>
+                router.push(connected ? '/dashboard' : '/community/players')
+              }
             >
               Home
             </MetaSecondaryButton>

--- a/packages/web/pages/guild/[guildname].tsx
+++ b/packages/web/pages/guild/[guildname].tsx
@@ -164,7 +164,7 @@ export const getStaticPaths: GetStaticPaths<QueryParams> = async () => {
     paths: guildnames.map((guildname) => ({
       params: { guildname },
     })),
-    fallback: false,
+    fallback: 'blocking',
   };
 };
 

--- a/packages/web/pages/guild/[guildname].tsx
+++ b/packages/web/pages/guild/[guildname].tsx
@@ -13,8 +13,8 @@ import {
   GetStaticPropsContext,
   InferGetStaticPropsType,
 } from 'next';
-import Error from 'next/error';
 import { useRouter } from 'next/router';
+import Page404 from 'pages/404';
 import React from 'react';
 import { BoxType } from 'utils/boxTypes';
 import { getGuildCoverImageFull } from 'utils/playerHelpers';
@@ -40,7 +40,7 @@ const GuildPage: React.FC<Props> = ({ guild }) => {
   }
 
   if (!guild) {
-    return <Error statusCode={404} />;
+    return <Page404 />;
   }
 
   const getBox = (name: string): React.ReactNode => {
@@ -164,7 +164,7 @@ export const getStaticPaths: GetStaticPaths<QueryParams> = async () => {
     paths: guildnames.map((guildname) => ({
       params: { guildname },
     })),
-    fallback: true,
+    fallback: false,
   };
 };
 
@@ -186,6 +186,7 @@ export const getStaticProps = async (
     props: {
       guild: guild === undefined ? null : guild,
       quests,
+      hideTopMenu: !guild,
     },
     revalidate: 1,
   };

--- a/packages/web/pages/player/[username].tsx
+++ b/packages/web/pages/player/[username].tsx
@@ -502,7 +502,7 @@ export const getStaticPaths: GetStaticPaths<QueryParams> = async () => {
     paths: playerUsernames.map((username) => ({
       params: { username },
     })),
-    fallback: false,
+    fallback: 'blocking',
   };
 };
 

--- a/packages/web/pages/player/[username].tsx
+++ b/packages/web/pages/player/[username].tsx
@@ -37,9 +37,10 @@ import {
   InferGetStaticPropsType,
 } from 'next';
 import Error from 'next/error';
-import { ReactElement, useCallback, useEffect, useMemo, useState } from 'react';
+import Page404 from 'pages/404';
+import React, { ReactElement, useCallback, useEffect, useMemo, useState } from 'react';
 import { Layout, Layouts, Responsive, WidthProvider } from 'react-grid-layout';
-import { BoxMetadata, BoxType, getBoxKey } from 'utils/boxTypes';
+import { BoxMetadata, BoxType, getBoxKey  } from 'utils/boxTypes';
 import {
   getPlayerBannerFull,
   getPlayerDescription,
@@ -53,13 +54,11 @@ const ResponsiveGridLayout = WidthProvider(Responsive);
 type Props = InferGetStaticPropsType<typeof getStaticProps>;
 
 export const PlayerPage: React.FC<Props> = ({ player }): ReactElement => {
-  if (!player) {
-    return <Error statusCode={404} />;
-  }
+  if (!player) return <Error statusCode={404} />;
+
   return (
+    // have to override pt in PageContainer
     <PageContainer p={0} pt={0} mt="-4.5rem">
-      {' '}
-      {/* have to override pt in PageContainer */}
       <HeadComponent
         title={`MetaGame Profile: ${getPlayerName(player)}`}
         description={(getPlayerDescription(player) ?? '').replace('\n', ' ')}
@@ -75,15 +74,15 @@ export const PlayerPage: React.FC<Props> = ({ player }): ReactElement => {
         w="full"
       />
       <Flex
-        w="100%"
-        h="100%"
+        w="full"
+        h="full"
         minH="100vh"
         p={4}
         pt="8rem"
         direction="column"
         align="center"
       >
-        <Grid player={player} />
+        <Grid {...{ player }} />
       </Flex>
     </PageContainer>
   );
@@ -181,9 +180,10 @@ export const Grid: React.FC<Props> = ({ player: initPlayer }): ReactElement => {
   ] = useUpdatePlayerProfileLayoutMutation();
   const [saving, setSaving] = useState(false);
 
-  const layoutsFromDB = player?.profileLayout
-    ? JSON.parse(player.profileLayout)
-    : null;
+  const layoutsFromDB = useMemo(
+    () => (player.profileLayout ? JSON.parse(player.profileLayout) : null),
+    [player.profileLayout],
+  );
 
   const [savedLayoutData, setSavedLayoutData] = useState<ProfileLayoutData>(
     layoutsFromDB || {
@@ -359,6 +359,8 @@ export const Grid: React.FC<Props> = ({ player: initPlayer }): ReactElement => {
     [currentLayoutItems],
   );
 
+  if (!player) return <Page404 />;
+
   return (
     <Box
       className="gridWrapper"
@@ -367,7 +369,7 @@ export const Grid: React.FC<Props> = ({ player: initPlayer }): ReactElement => {
       sx={wrapperSX}
       maxW="96rem"
       mb="12rem"
-      pt={isOwnProfile ? '0rem' : '4rem'}
+      pt={isOwnProfile ? 0 : '4rem'}
     >
       {isOwnProfile && (
         <ButtonGroup
@@ -382,7 +384,7 @@ export const Grid: React.FC<Props> = ({ player: initPlayer }): ReactElement => {
         >
           {changed && editable && (
             <MetaButton
-              aria-label="Edit layout"
+              aria-label="Edit Layout"
               colorScheme="purple"
               _hover={{ background: 'purple.600' }}
               textTransform="uppercase"
@@ -500,7 +502,7 @@ export const getStaticPaths: GetStaticPaths<QueryParams> = async () => {
     paths: playerUsernames.map((username) => ({
       params: { username },
     })),
-    fallback: true,
+    fallback: false,
   };
 };
 
@@ -523,6 +525,7 @@ export const getStaticProps = async (
     props: {
       player: player ?? null, // must be serializable
       key: username.toLowerCase(),
+      hideTopMenu: !player,
     },
     revalidate: 1,
   };

--- a/packages/web/pages/quest/[id]/complete.tsx
+++ b/packages/web/pages/quest/[id]/complete.tsx
@@ -111,7 +111,7 @@ type QueryParams = { id: string };
 
 export const getStaticPaths: GetStaticPaths<QueryParams> = async () => ({
   paths: [],
-  fallback: true,
+  fallback: 'blocking',
 });
 
 export const getStaticProps = async (

--- a/packages/web/pages/quest/[id]/complete.tsx
+++ b/packages/web/pages/quest/[id]/complete.tsx
@@ -10,7 +10,6 @@ import {
   GetStaticPropsContext,
   InferGetStaticPropsType,
 } from 'next';
-import Error from 'next/error';
 import { useRouter } from 'next/router';
 import React from 'react';
 
@@ -18,6 +17,7 @@ import { PageContainer } from '../../../components/Container';
 import { CompletionForm } from '../../../components/Quest/CompletionForm';
 import { getSsrClient } from '../../../graphql/client';
 import { useUser } from '../../../lib/hooks';
+import Page404 from '../../404';
 
 type Props = InferGetStaticPropsType<typeof getStaticProps>;
 
@@ -39,7 +39,7 @@ const SubmitQuestCompletionPage: React.FC<Props> = ({ quest }) => {
   }
 
   if (!quest) {
-    return <Error statusCode={404} />;
+    return <Page404 />;
   }
 
   const onSubmit = (data: CreateQuestCompletionInput) => {
@@ -124,6 +124,7 @@ export const getStaticProps = async (
   return {
     props: {
       quest: quest ?? null,
+      hideTopMenu: !quest,
     },
     revalidate: 1,
   };


### PR DESCRIPTION
## Overview
Custom 404 Page does not shown for nested routes. That has been fixed with correct redirection from the 404 page to the homepage or dashboard.

**What features/fixes does this PR include?**

A path like "/player/404", "/guild/404" and "/quest/[id]/completed" were using regular 404 pages and I changed them to show our custom 404 page.

**Please provide the GitHub issue number**

https://github.com/MetaFam/TheGame/issues/1030

Closes #

https://github.com/MetaFam/TheGame/issues/1030

## Implementation

**Describe technical (nontrivial / non-obvious) parts of your code**

I have to add fallback:false and hideTopMenu:true props to the getStaticProps, otherwise the page tries to build the page with header and then redirects to 404 , but now it is just showing the custom 404 page without any header.

Also the redirection to homepage from 404 has been fixed according to the @vidvidvid suggestion.

@vidvidvid 's comment:
![image](https://user-images.githubusercontent.com/34514974/148759342-498aa4cb-0d1b-4a4e-91d3-1f95cb04defb.png)
