### PR TITLE
fixed overlap of stats bar on mobile & tablet

### DIFF
--- a/packages/web/components/Container.tsx
+++ b/packages/web/components/Container.tsx
@@ -11,7 +11,9 @@ export const PageContainer: React.FC<Props> = ({ children, ...props }) => (
     w="100%"
     h="100%"
     minH="100vh"
-    p={[4, 8, 12]}
+    px={[4, 8, 12]}
+    pt={[4, 8, 12]}
+    pb={[20, 20, 20, 12]}
     direction="column"
     align="center"
     backgroundImage={`url(${BackgroundImage})`}

--- a/packages/web/components/PlayerStatsBar.tsx
+++ b/packages/web/components/PlayerStatsBar.tsx
@@ -38,6 +38,7 @@ const PlayerStats = () => {
       justifyContent={connected ? 'space-between' : 'center'}
       flex="1"
       minW="100vw"
+      height="72px"
       bg="rgba(0,0,0,0.75)"
       borderColor="#2B2244"
       sx={{ backdropFilter: 'blur(10px)' }}
@@ -45,13 +46,12 @@ const PlayerStats = () => {
       bottom="0"
       zIndex="200"
       boxSizing="border-box"
-      mt="auto"
+      my="auto"
       mr="0"
-      mb="auto"
     >
       {connected && !!user?.player ? (
         <>
-          <Flex pt={2} pb={6} px={2}>
+          <Flex py="10px" px={2}>
             <Menu strategy="fixed" offset={[-7, 9]}>
               <MenuButton
                 bg="transparent"
@@ -108,14 +108,7 @@ const PlayerStats = () => {
               </Text>
             </Stack>
           </Flex>
-          <Flex
-            mr={2}
-            mt={2}
-            flexWrap="wrap"
-            height="100%"
-            alignSelf="baseline"
-            justifyContent="flex-end"
-          >
+          <Flex mr={2} mt={2} justifyContent="flex-end">
             <Badge
               display="flex"
               minH="fill"


### PR DESCRIPTION
## Overview

**What features/fixes does this PR include?**
The bottom of pages were overlapped by the player stats bar on mobile and tablet

Closes #473 

## Implementation

**Describe technical (nontrivial / non-obvious) parts of your code**
Added padding on the bottom of pages and made the stats bar a fixed height
