### PR TITLE
rank up notification

### DIFF
--- a/packages/backend/src/handlers/triggers/playerRankUpdated.ts
+++ b/packages/backend/src/handlers/triggers/playerRankUpdated.ts
@@ -1,10 +1,12 @@
 /* eslint-disable no-console */
 import { createDiscordClient } from '@metafam/discord-bot';
 import { Constants } from '@metafam/utils';
+import { TextChannel } from 'discord.js';
 
 import { CONFIG } from '../../config';
 import { Player, PlayerRank_Enum } from '../../lib/autogen/hasura-sdk';
 import { client } from '../../lib/hasuraClient';
+import { playerRankedUp } from '../../lib/rankHelpers';
 import { TriggerPayload } from './types';
 
 type RankRoleIds = { [rank in PlayerRank_Enum]: string };
@@ -106,6 +108,16 @@ export const playerRankUpdated = async (payload: TriggerPayload<Player>) => {
       console.warn(`Discord role associated with ${newRank} was not found!`);
     } else {
       await discordPlayer.roles.add([discordRoleForRank]);
+
+      // We should check whether this role is higher than the previous
+      if (playerRankedUp(oldPlayer?.rank, newPlayer?.rank)) {
+        const propsChannel = discordClient.channels.cache.get(
+          Constants.DISCORD_PROPS_CHANNEL_ID,
+        ) as TextChannel;
+        propsChannel.send(
+          `Props to ${newPlayer?.username} for becoming ${newRank}`,
+        );
+      }
       console.log(`${newPlayer?.profile?.username}: added role ${newRank}`);
     }
   } catch (e) {

--- a/packages/backend/src/handlers/triggers/playerRankUpdated.ts
+++ b/packages/backend/src/handlers/triggers/playerRankUpdated.ts
@@ -6,7 +6,7 @@ import { TextChannel } from 'discord.js';
 import { CONFIG } from '../../config';
 import { Player, PlayerRank_Enum } from '../../lib/autogen/hasura-sdk';
 import { client } from '../../lib/hasuraClient';
-import { playerRankedUp } from '../../lib/rankHelpers';
+import { isRankHigher } from '../../lib/rankHelpers';
 import { TriggerPayload } from './types';
 
 type RankRoleIds = { [rank in PlayerRank_Enum]: string };
@@ -110,12 +110,12 @@ export const playerRankUpdated = async (payload: TriggerPayload<Player>) => {
       await discordPlayer.roles.add([discordRoleForRank]);
 
       // We should check whether this role is higher than the previous
-      if (playerRankedUp(oldPlayer?.rank, newPlayer?.rank)) {
+      if (isRankHigher(oldPlayer?.rank, newPlayer?.rank)) {
         const propsChannel = discordClient.channels.cache.get(
           Constants.DISCORD_PROPS_CHANNEL_ID,
         ) as TextChannel;
         propsChannel.send(
-          `Props to ${discordPlayer.toString()} for becoming ${newRank}, congrats!`,
+          `Props to ${discordPlayer} for becoming ${newRank}, congrats!`,
         );
       }
       console.log(`${newPlayer?.profile?.username}: added role ${newRank}`);

--- a/packages/backend/src/handlers/triggers/playerRankUpdated.ts
+++ b/packages/backend/src/handlers/triggers/playerRankUpdated.ts
@@ -115,7 +115,7 @@ export const playerRankUpdated = async (payload: TriggerPayload<Player>) => {
           Constants.DISCORD_PROPS_CHANNEL_ID,
         ) as TextChannel;
         propsChannel.send(
-          `Props to ${newPlayer?.username} for becoming ${newRank}, congrats!`,
+          `Props to ${discordPlayer.toString()} for becoming ${newRank}, congrats!`,
         );
       }
       console.log(`${newPlayer?.profile?.username}: added role ${newRank}`);

--- a/packages/backend/src/handlers/triggers/playerRankUpdated.ts
+++ b/packages/backend/src/handlers/triggers/playerRankUpdated.ts
@@ -115,7 +115,7 @@ export const playerRankUpdated = async (payload: TriggerPayload<Player>) => {
           Constants.DISCORD_PROPS_CHANNEL_ID,
         ) as TextChannel;
         propsChannel.send(
-          `Props to ${newPlayer?.username} for becoming ${newRank}`,
+          `Props to ${newPlayer?.username} for becoming ${newRank}, congrats!`,
         );
       }
       console.log(`${newPlayer?.profile?.username}: added role ${newRank}`);

--- a/packages/backend/src/lib/rankHelpers.ts
+++ b/packages/backend/src/lib/rankHelpers.ts
@@ -23,3 +23,15 @@ export function computeRank(totalRankIndex: number): PlayerRank_Enum | null {
     RANKS,
   ) as PlayerRank_Enum | null;
 }
+
+export function playerRankedUp(
+  oldRank: PlayerRank_Enum | null | undefined,
+  newRank: PlayerRank_Enum | null | undefined,
+): boolean {
+  if (oldRank === null || oldRank === undefined) return true;
+  if (newRank === null || newRank === undefined) return false;
+
+  const oldIndex = RANKS.indexOf(oldRank);
+  const newIndex = RANKS.indexOf(newRank);
+  return newIndex < oldIndex;
+}

--- a/packages/backend/src/lib/rankHelpers.ts
+++ b/packages/backend/src/lib/rankHelpers.ts
@@ -24,12 +24,12 @@ export function computeRank(totalRankIndex: number): PlayerRank_Enum | null {
   ) as PlayerRank_Enum | null;
 }
 
-export function playerRankedUp(
+export function isRankHigher(
   oldRank: PlayerRank_Enum | null | undefined,
   newRank: PlayerRank_Enum | null | undefined,
 ): boolean {
-  if (oldRank === null || oldRank === undefined) return true;
-  if (newRank === null || newRank === undefined) return false;
+  if (oldRank == null) return true;
+  if (newRank == null) return false;
 
   const oldIndex = RANKS.indexOf(oldRank);
   const newIndex = RANKS.indexOf(newRank);

--- a/packages/utils/src/constants.ts
+++ b/packages/utils/src/constants.ts
@@ -6,6 +6,7 @@ export const DISCORD_BOT_PERMISSIONS = '268435456';
 export const DISCORD_OAUTH_SCOPES = 'bot identify guilds';
 export const DISCORD_OAUTH_CALLBACK_PATH = `${WEB_PATH_JOIN_GUILD}/auth`;
 export const METAFAM_DISCORD_GUILD_ID = '629411177947987986';
+export const DISCORD_PROPS_CHANNEL_ID = '718557002221224037';
 
 export const SC_OUTPUT_BASE =
   'https://raw.githubusercontent.com/MetaFam/XP/gh-pages/';


### PR DESCRIPTION
## Overview
Added a trigger in the backend which posts a message in the props channel when a player ranks up.
When the player goes down a rank nothing happens.

Closes #837 

## Implementation

Added a function to the utils package which determines the new rank is higher than the old rank.
The backend triggers the message to the props channel. 
