### PR TITLE
Ensure that only known users can go through the guild setup process

### DIFF
--- a/packages/web/components/Forms/Field.tsx
+++ b/packages/web/components/Forms/Field.tsx
@@ -28,3 +28,9 @@ export const Field: React.FC<FieldProps> = ({ children, error, label }) => (
     {children}
   </Flex>
 );
+
+export const FieldDescription: React.FC = ({ children }) => (
+  <Text ml={4} mt={1} fontSize="sm">
+    {children}
+  </Text>
+);

--- a/packages/web/components/Forms/Field.tsx
+++ b/packages/web/components/Forms/Field.tsx
@@ -9,7 +9,7 @@ type FieldProps = {
 };
 
 export const Field: React.FC<FieldProps> = ({ children, error, label }) => (
-  <Flex mb={2} w="100%" align="center" direction="column">
+  <Flex pb={3} w="100%" direction="column">
     <Flex justify="space-between" w="100%" mb={2}>
       <Text textStyle="caption" textAlign="left" ml={4}>
         {label}

--- a/packages/web/components/Guild/GuildForm.tsx
+++ b/packages/web/components/Guild/GuildForm.tsx
@@ -10,7 +10,7 @@ import {
   VStack,
 } from '@metafam/ds';
 import { SelectOption } from '@metafam/ds/src/MultiSelect';
-import { Field } from 'components/Forms/Field';
+import { Field, FieldDescription } from 'components/Forms/Field';
 import { MetaLink } from 'components/Link';
 import {
   DiscordRole,
@@ -160,11 +160,7 @@ export const GuildForm: React.FC<Props> = ({
   }, [workingGuild, guildMetadata, roleOptions, reset]);
 
   return (
-    <Box
-      w="100%"
-      maxW="40rem"
-      sx={{ '.description': { ml: 4, mt: 1, fontSize: 'sm' } }}
-    >
+    <Box w="100%" maxW="40rem">
       <VStack>
         <Field label="Guildname" error={errors.guildname}>
           <Input
@@ -185,9 +181,9 @@ export const GuildForm: React.FC<Props> = ({
             isInvalid={!!errors.guildname}
             background="dark"
           />
-          <span className="description">
+          <FieldDescription>
             A unique identifier for your guild, like a username.
-          </span>
+          </FieldDescription>
         </Field>
         <Field label="Name" error={errors.name}>
           <Input
@@ -204,27 +200,27 @@ export const GuildForm: React.FC<Props> = ({
             isInvalid={!!errors.name}
             background="dark"
           />
-          <span className="description">
+          <FieldDescription>
             Your guild&apos;s name. This is what will show throughout MetaGame.
-          </span>
+          </FieldDescription>
         </Field>
         <Field label="Description" error={errors.description}>
           <Textarea
-            placeholder="What’s your guild all about?"
+            placeholder="What's your guild all about?"
             {...register('description')}
             background="dark"
           />
         </Field>
         <Field label="Logo URL" error={errors.logoUrl}>
           <Input {...register('logoUrl')} background="dark" />
-          <span className="description">
+          <FieldDescription>
             Logos should be square (same width and height) and reasonably
             high-resolution.
-          </span>
+          </FieldDescription>
         </Field>
         <Field label="Website URL" error={errors.websiteUrl}>
           <Input {...register('websiteUrl')} background="dark" />
-          <span className="description">Your guild&apos;s main website.</span>
+          <FieldDescription>Your guild&apos;s main website.</FieldDescription>
         </Field>
         <Field label="Discord Invite URL" error={errors.discordInviteUrl}>
           <Input
@@ -232,15 +228,15 @@ export const GuildForm: React.FC<Props> = ({
             {...register('discordInviteUrl')}
             background="dark"
           />
-          <span className="description">
+          <FieldDescription>
             A public invite URL for your Discord server.
-          </span>
+          </FieldDescription>
         </Field>
         <Field label="Join URL" error={errors.joinUrl}>
           <Input {...register('joinUrl')} background="dark" />
-          <span className="description">
+          <FieldDescription>
             The URL that the <q>JOIN</q> button will point to.
-          </span>
+          </FieldDescription>
         </Field>
         <Field label="Twitter URL" error={errors.twitterUrl}>
           <Input
@@ -248,9 +244,9 @@ export const GuildForm: React.FC<Props> = ({
             {...register('twitterUrl')}
             background="dark"
           />
-          <span className="description">
+          <FieldDescription>
             Your guild&apos;s home on Twitter.
-          </span>
+          </FieldDescription>
         </Field>
         <Field label="GitHub URL" error={errors.githubUrl}>
           <Input
@@ -258,7 +254,7 @@ export const GuildForm: React.FC<Props> = ({
             {...register('githubUrl')}
             background="dark"
           />
-          <span className="description">Your guild&apos;s home on GitHub.</span>
+          <FieldDescription>Your guild&apos;s home on GitHub.</FieldDescription>
         </Field>
         <Field label="DAO Address" error={errors.daoAddress}>
           <Input
@@ -266,17 +262,17 @@ export const GuildForm: React.FC<Props> = ({
             {...register('daoAddress')}
             background="dark"
           />
-          <span className="description">
+          <FieldDescription>
             If your guild has a DAO, enter its address here. This is the address
             that will be used to look up your DAO's information from the{' '}
             <MetaLink
               isExternal
               href="https://thegraph.com/hosted-service/subgraph/odyssy-automaton/daohaus"
             >
-              DaoHaus Supergraph
+              DaoHaus Subgraph
             </MetaLink>{' '}
             on Mainnet, Polygon and xDai.
-          </span>
+          </FieldDescription>
         </Field>
         <Field label="Type" error={errors.type}>
           <Select
@@ -324,10 +320,10 @@ export const GuildForm: React.FC<Props> = ({
                     <MultiSelect isMulti options={roleOptions} {...props} />
                   )}
                 />
-                <span className="description">
+                <FieldDescription>
                   Members of your Discord server with these roles will have
                   administration privileges.
-                </span>
+                </FieldDescription>
               </Field>
               <Field
                 label="Membership Roles"
@@ -348,10 +344,10 @@ export const GuildForm: React.FC<Props> = ({
                     <MultiSelect isMulti options={roleOptions} {...props} />
                   )}
                 />
-                <span className="description">
+                <FieldDescription>
                   Members of your Discord server with these roles will be
                   considered members of this guild.
-                </span>
+                </FieldDescription>
               </Field>
             </>
           )}

--- a/packages/web/components/Guild/GuildForm.tsx
+++ b/packages/web/components/Guild/GuildForm.tsx
@@ -11,6 +11,7 @@ import {
 } from '@metafam/ds';
 import { SelectOption } from '@metafam/ds/src/MultiSelect';
 import { Field } from 'components/Forms/Field';
+import { MetaLink } from 'components/Link';
 import {
   DiscordRole,
   GuildFragmentFragment,
@@ -159,7 +160,11 @@ export const GuildForm: React.FC<Props> = ({
   }, [workingGuild, guildMetadata, roleOptions, reset]);
 
   return (
-    <Box w="100%" maxW="40rem">
+    <Box
+      w="100%"
+      maxW="40rem"
+      sx={{ '.description': { ml: 4, mt: 1, fontSize: 'sm' } }}
+    >
       <VStack>
         <Field label="Guildname" error={errors.guildname}>
           <Input
@@ -180,7 +185,9 @@ export const GuildForm: React.FC<Props> = ({
             isInvalid={!!errors.guildname}
             background="dark"
           />
-          <span>A unique identifier for your guild, like a username.</span>
+          <span className="description">
+            A unique identifier for your guild, like a username.
+          </span>
         </Field>
         <Field label="Name" error={errors.name}>
           <Input
@@ -197,7 +204,7 @@ export const GuildForm: React.FC<Props> = ({
             isInvalid={!!errors.name}
             background="dark"
           />
-          <span>
+          <span className="description">
             Your guild&apos;s name. This is what will show throughout MetaGame.
           </span>
         </Field>
@@ -210,14 +217,14 @@ export const GuildForm: React.FC<Props> = ({
         </Field>
         <Field label="Logo URL" error={errors.logoUrl}>
           <Input {...register('logoUrl')} background="dark" />
-          <span>
+          <span className="description">
             Logos should be square (same width and height) and reasonably
             high-resolution.
           </span>
         </Field>
         <Field label="Website URL" error={errors.websiteUrl}>
           <Input {...register('websiteUrl')} background="dark" />
-          <span>Your guild&apos;s main website.</span>
+          <span className="description">Your guild&apos;s main website.</span>
         </Field>
         <Field label="Discord Invite URL" error={errors.discordInviteUrl}>
           <Input
@@ -225,11 +232,13 @@ export const GuildForm: React.FC<Props> = ({
             {...register('discordInviteUrl')}
             background="dark"
           />
-          <span>A public invite URL for your Discord server.</span>
+          <span className="description">
+            A public invite URL for your Discord server.
+          </span>
         </Field>
         <Field label="Join URL" error={errors.joinUrl}>
           <Input {...register('joinUrl')} background="dark" />
-          <span>
+          <span className="description">
             The URL that the <q>JOIN</q> button will point to.
           </span>
         </Field>
@@ -239,7 +248,9 @@ export const GuildForm: React.FC<Props> = ({
             {...register('twitterUrl')}
             background="dark"
           />
-          <span>Your guild&apos;s home on Twitter.</span>
+          <span className="description">
+            Your guild&apos;s home on Twitter.
+          </span>
         </Field>
         <Field label="GitHub URL" error={errors.githubUrl}>
           <Input
@@ -247,7 +258,7 @@ export const GuildForm: React.FC<Props> = ({
             {...register('githubUrl')}
             background="dark"
           />
-          <span>Your guild&apos;s home on GitHub.</span>
+          <span className="description">Your guild&apos;s home on GitHub.</span>
         </Field>
         <Field label="DAO Address" error={errors.daoAddress}>
           <Input
@@ -255,7 +266,17 @@ export const GuildForm: React.FC<Props> = ({
             {...register('daoAddress')}
             background="dark"
           />
-          <span>If your guild has a DAO, enter its address here.</span>
+          <span className="description">
+            If your guild has a DAO, enter its address here. This is the address
+            that will be used to look up your DAO's information from the{' '}
+            <MetaLink
+              isExternal
+              href="https://thegraph.com/hosted-service/subgraph/odyssy-automaton/daohaus"
+            >
+              DaoHaus Supergraph
+            </MetaLink>{' '}
+            on Mainnet, Polygon and xDai.
+          </span>
         </Field>
         <Field label="Type" error={errors.type}>
           <Select
@@ -276,7 +297,7 @@ export const GuildForm: React.FC<Props> = ({
             ))}
           </Select>
         </Field>
-        <Box py={5}>
+        <Box py={5} w="100%">
           {fetchingRoles ? (
             <Box>
               Fetching roles from Discord…
@@ -303,7 +324,7 @@ export const GuildForm: React.FC<Props> = ({
                     <MultiSelect isMulti options={roleOptions} {...props} />
                   )}
                 />
-                <span>
+                <span className="description">
                   Members of your Discord server with these roles will have
                   administration privileges.
                 </span>
@@ -327,7 +348,7 @@ export const GuildForm: React.FC<Props> = ({
                     <MultiSelect isMulti options={roleOptions} {...props} />
                   )}
                 />
-                <span>
+                <span className="description">
                   Members of your Discord server with these roles will be
                   considered members of this guild.
                 </span>

--- a/packages/web/components/Guild/GuildJoin.tsx
+++ b/packages/web/components/Guild/GuildJoin.tsx
@@ -1,5 +1,6 @@
 import {
   Box,
+  Flex,
   Image,
   ListItem,
   MetaButton,
@@ -11,12 +12,14 @@ import { Constants, generateUUID } from '@metafam/utils';
 import { FlexContainer } from 'components/Container';
 import { MetaLink } from 'components/Link';
 import { CONFIG } from 'config';
+import { useUser } from 'lib/hooks';
 import { get, set } from 'lib/store';
 import React, { useEffect, useState } from 'react';
 
 export const discordAuthStateGuidKey = 'metagame-add-guild';
 
 export const GuildJoin: React.FC = () => {
+  const { user } = useUser();
   const discordOAuthCallbackURL = `${CONFIG.publicURL}/${Constants.DISCORD_OAUTH_CALLBACK_PATH}`;
 
   const [stateGuid, setStateGuid] = useState<string>();
@@ -72,20 +75,30 @@ export const GuildJoin: React.FC = () => {
             <MetaLink isExternal href="https://discord.com/">
               Discord
             </MetaLink>{' '}
-            server. Clicking the link below will redirect to a Discord page
-            asking for your permission to collect certain relevant information
-            about your guild.
+            server.
           </Text>
-          {stateGuid?.length && (
-            <MetaButton
-              size="lg"
-              maxW="15rem"
-              mt={4}
-              as="a"
-              href={discordAuthURL}
-            >
-              Apply to Join
-            </MetaButton>
+          {stateGuid?.length && user?.player ? (
+            <>
+              <Text pt={4}>
+                Clicking the link below will redirect to a Discord page asking
+                for your permission to collect certain relevant information
+                about your guild.
+              </Text>
+              <MetaButton
+                size="lg"
+                maxW="15rem"
+                mt={4}
+                as="a"
+                href={discordAuthURL}
+              >
+                Apply to Join
+              </MetaButton>
+            </>
+          ) : (
+            <Flex fontStyle="italic" mt={4}>
+              Please log in or create a player profile by pressing the "Connect"
+              button to start the guild setup process.
+            </Flex>
           )}
         </Box>
       </Box>


### PR DESCRIPTION
## Overview

**What features/fixes does this PR include?**

- Only known users (those with a connected profile) can go through the guild setup process. This enforces that. 
- Form visual improvements
- Added more detail to the "DAO address" field

Closes #1063 

## Implementation

**Side effects**

I made a CSS change to the shared `Field` component to make it less opinionated.

## Assets

<img width="757" alt="image" src="https://user-images.githubusercontent.com/1402582/152044868-d9058db6-08d5-4bd2-b252-b58a6781de68.png">
