### PR TITLE
Clean up and simplify the type system

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -15,3 +15,6 @@ updates:
     directory: / # default location of `.github/workflows`
     schedule:
       interval: daily
+    ignore:
+      - dependency-name: '*'
+        update-types: [version-update:semver-patch]

--- a/.github/workflows/PR-CI.yml
+++ b/.github/workflows/PR-CI.yml
@@ -17,18 +17,18 @@ jobs:
 
     steps:
       - name: Cancel Previous Runs
-        uses: styfle/cancel-workflow-action@0.4.0
+        uses: styfle/cancel-workflow-action@0.9.1
         with:
-          access_token: ${{ github.token }}
+          access_token: ${{github.token}}
       - uses: actions/checkout@v2
-      - uses: actions/setup-node@v1
+      - uses: actions/setup-node@v2.5.1
         with:
           node-version: 16.x
 
       - uses: actions/cache@v2
         with:
           path: '**/node_modules'
-          key: nodeModules-${{ runner.os }}-${{ hashFiles('**/yarn.lock') }}
+          key: nodeModules-${{runner.os}}-${{hashFiles('**/yarn.lock')}}
 
       - name: Install packages
         run: yarn --frozen-lockfile

--- a/.github/workflows/gcp-deploy.yaml
+++ b/.github/workflows/gcp-deploy.yaml
@@ -51,7 +51,7 @@ jobs:
 
     steps:
       - name: Cancel Existing Runs
-        uses: styfle/cancel-workflow-action@0.4.0
+        uses: styfle/cancel-workflow-action@0.9.1
         with:
           access_token: ${{github.token}}
 
@@ -137,7 +137,7 @@ jobs:
 
     steps:
       - name: Set Up gcloud CLI
-        uses: google-github-actions/setup-gcloud@v0.2.1
+        uses: google-github-actions/setup-gcloud@v0.5.0
         with:
           project_id: ${{needs.env.outputs.PROJECT_ID}}
           service_account_key: ${{secrets.GCP_SA_KEY}}
@@ -170,7 +170,7 @@ jobs:
 
     steps:
       - name: Set Up gcloud CLI
-        uses: google-github-actions/setup-gcloud@v0.2.1
+        uses: google-github-actions/setup-gcloud@v0.5.0
         with:
           project_id: ${{needs.env.outputs.PROJECT_ID}}
           service_account_key: ${{secrets.GCP_SA_KEY}}
@@ -194,7 +194,7 @@ jobs:
 
     steps:
       - name: Set Up gcloud CLI
-        uses: google-github-actions/setup-gcloud@v0.2.1
+        uses: google-github-actions/setup-gcloud@v0.5.0
         with:
           project_id: ${{needs.env.outputs.PROJECT_ID}}
           service_account_key: ${{secrets.GCP_SA_KEY}}
@@ -220,7 +220,7 @@ jobs:
           password: ${{secrets.GCP_SA_KEY}}
 
       - name: Set Up gcloud CLI
-        uses: google-github-actions/setup-gcloud@v0.2.1
+        uses: google-github-actions/setup-gcloud@v0.5.0
         with:
           project_id: ${{needs.env.outputs.PROJECT_ID}}
           service_account_key: ${{secrets.GCP_SA_KEY}}
@@ -248,7 +248,7 @@ jobs:
             . -f docker/backend/Dockerfile \
               --tag ${{needs.env.outputs.BACKEND_TAG}} \
               --build-arg GRAPHQL_URL=${{needs.env.outputs.GRAPHQL_URL}}
-          cache_key: "${{hashFiles('packages/backend/**')}}"
+          cache_key: "${{hashFiles('packages/backend/**', 'packages/utils/**', 'package.json')}}"
 
       - name: "Login to Registry: ${{needs.env.outputs.DOCKER_REGISTRY}}"
         uses: docker/login-action@v1
@@ -267,7 +267,7 @@ jobs:
 
     steps:
       - name: Set Up gcloud CLI
-        uses: google-github-actions/setup-gcloud@v0.2.1
+        uses: google-github-actions/setup-gcloud@v0.5.0
         with:
           project_id: ${{needs.env.outputs.PROJECT_ID}}
           service_account_key: ${{secrets.GCP_SA_KEY}}
@@ -296,7 +296,7 @@ jobs:
 
     steps:
       - name: Set Up gcloud CLI
-        uses: google-github-actions/setup-gcloud@v0.2.1
+        uses: google-github-actions/setup-gcloud@v0.5.0
         with:
           project_id: ${{needs.env.outputs.PROJECT_ID}}
           service_account_key: ${{secrets.GCP_SA_KEY}}
@@ -322,7 +322,7 @@ jobs:
           password: ${{secrets.GCP_SA_KEY}}
 
       - name: Set Up gcloud CLI
-        uses: google-github-actions/setup-gcloud@v0.2.1
+        uses: google-github-actions/setup-gcloud@v0.5.0
         with:
           project_id: ${{needs.env.outputs.PROJECT_ID}}
           service_account_key: ${{secrets.GCP_SA_KEY}}
@@ -351,7 +351,7 @@ jobs:
               --tag ${{needs.env.outputs.HASURA_TAG}} \
               --build-arg BACKEND_HOST=${{needs.env.outputs.BACKEND_HOST}} \
               --build-arg BACKEND_PROTOCOL=https
-          cache_key: "${{hashFiles('hasura/**')}}"
+          cache_key: "${{hashFiles('hasura/**', 'package.json')}}"
 
       - name: "Login to Registry: ${{needs.env.outputs.DOCKER_REGISTRY}}"
         uses: docker/login-action@v1
@@ -375,7 +375,7 @@ jobs:
 
     steps:
       - name: Set Up gcloud CLI
-        uses: google-github-actions/setup-gcloud@v0.2.1
+        uses: google-github-actions/setup-gcloud@v0.5.0
         with:
           project_id: ${{needs.env.outputs.PROJECT_ID}}
           service_account_key: ${{secrets.GCP_SA_KEY}}
@@ -405,7 +405,7 @@ jobs:
 
     steps:
       - name: Set Up gcloud CLI
-        uses: google-github-actions/setup-gcloud@v0.2.1
+        uses: google-github-actions/setup-gcloud@v0.5.0
         with:
           project_id: ${{needs.env.outputs.PROJECT_ID}}
           service_account_key: ${{secrets.GCP_SA_KEY}}
@@ -424,7 +424,7 @@ jobs:
 
     steps:
       - name: Set Up gcloud CLI
-        uses: google-github-actions/setup-gcloud@v0.2.1
+        uses: google-github-actions/setup-gcloud@v0.5.0
         with:
           project_id: ${{needs.env.outputs.PROJECT_ID}}
           service_account_key: ${{secrets.GCP_SA_KEY}}
@@ -452,7 +452,7 @@ jobs:
             . -f docker/frontend/Dockerfile \
               --tag ${{needs.env.outputs.FRONTEND_TAG}} \
               --build-arg GRAPHQL_URL=${{needs.env.outputs.GRAPHQL_URL}}
-          cache_key: "${{hashFiles('packages/web/**', 'packages/design-system/**')}}"
+          cache_key: "${{hashFiles('packages/web/**', 'packages/design-system/**', 'packages/utils/**', 'package.json')}}"
 
       - name: "Login to Registry: ${{needs.env.outputs.DOCKER_REGISTRY}}"
         uses: docker/login-action@v1
@@ -471,7 +471,7 @@ jobs:
 
     steps:
       - name: Set Up gcloud CLI
-        uses: google-github-actions/setup-gcloud@v0.2.1
+        uses: google-github-actions/setup-gcloud@v0.5.0
         with:
           project_id: ${{needs.env.outputs.PROJECT_ID}}
           service_account_key: ${{secrets.GCP_SA_KEY}}

--- a/.github/workflows/gcp-undeploy.yaml
+++ b/.github/workflows/gcp-undeploy.yaml
@@ -22,10 +22,10 @@ jobs:
 
     steps:
       - name: Set up gcloud CLI
-        uses: google-github-actions/setup-gcloud@v0.2.1
+        uses: google-github-actions/setup-gcloud@v0.5.0
         with:
-          project_id: ${{ env.PROJECT_ID }}
-          service_account_key: ${{ secrets.GCP_SA_KEY }}
+          project_id: ${{env.PROJECT_ID}}
+          service_account_key: ${{secrets.GCP_SA_KEY}}
           export_default_credentials: true
 
       - name: Undeploy Backend
@@ -64,4 +64,4 @@ jobs:
         uses: thollander/actions-comment-pull-request@v1
         with:
           message: Successfully undeployed the Preview of this Pull Request
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GITHUB_TOKEN: ${{github.token}}

--- a/.github/workflows/nightly-merge.yml
+++ b/.github/workflows/nightly-merge.yml
@@ -13,10 +13,10 @@ jobs:
         uses: actions/checkout@v1
 
       - name: Nightly Merge
-        uses: robotology/gh-action-nightly-merge@v1.3.1
+        uses: robotology/gh-action-nightly-merge@v1.3.2
         with:
           stable_branch: 'master'
           development_branch: 'develop'
           allow_ff: true
         env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GITHUB_TOKEN: ${{github.token}}

--- a/package.json
+++ b/package.json
@@ -86,7 +86,8 @@
   },
   "resolutions": {
     "bcrypto": "5.2.0",
-    "typescript": "4.5.4"
+    "typescript": "4.5.4",
+    "@ceramicnetwork/common": "1.11.0"
   },
   "dependencies": {
     "bottleneck": "2.19.5",

--- a/packages/backend/codegen.yml
+++ b/packages/backend/codegen.yml
@@ -2,8 +2,8 @@ overwrite: true
 require:
   - ts-node/register
 generates:
-  ./src/handlers/remote-schemas/autogen/types.ts:
-    schema: './src/handlers/remote-schemas/typeDefs.ts'
+  src/handlers/remote-schemas/autogen/types.ts:
+    schema: src/handlers/remote-schemas/typeDefs.ts
     plugins:
       - typescript
       - typescript-resolvers
@@ -13,10 +13,10 @@ generates:
       noSchemaStitching: true
       avoidOptionals: true
       maybeValue: 'T extends PromiseLike<infer U> ? Promise<U | null> : T | null | undefined'
-  ./src/lib/autogen/hasura-sdk.ts:
+  src/lib/autogen/hasura-sdk.ts:
     schema: '../../schema.graphql'
     documents:
-      - ./src/handlers/graphql/**/(!(*.d)).ts
+      - src/handlers/graphql/**/(!(*.d)).ts
     plugins:
       - typescript
       - typescript-operations
@@ -27,10 +27,11 @@ generates:
       immutableTypes: true
       scalars:
         account_type: "'ETHEREUM' | 'DISCORD' | 'GITHUB' | 'TWITTER' | 'DISCOURSE'"
-  ./src/lib/autogen/daohaus-sdk.ts:
+      dedupeOperationSuffix: true
+  src/lib/autogen/daohaus-sdk.ts:
     schema: 'https://api.thegraph.com/subgraphs/name/odyssy-automaton/daohaus'
     documents:
-      - ./src/handlers/remote-schemas/resolvers/daohaus/**/(!(*.d)).ts
+      - src/handlers/remote-schemas/resolvers/daohaus/**/(!(*.d)).ts
     plugins:
       - typescript
       - typescript-operations
@@ -39,10 +40,11 @@ generates:
           content: '/* eslint-disable */'
     config:
       avoidOptionals: true
-  ./src/lib/autogen/seedgraph-sdk.ts:
+      dedupeOperationSuffix: true
+  src/lib/autogen/seedgraph-sdk.ts:
     schema: 'https://api.thegraph.com/subgraphs/name/dan13ram/seed-graph'
     documents:
-      - ./src/handlers/remote-schemas/resolvers/seedGraph/**/(!(*.d)).ts
+      - src/handlers/remote-schemas/resolvers/seedGraph/**/(!(*.d)).ts
     plugins:
       - typescript
       - typescript-operations
@@ -51,3 +53,4 @@ generates:
           content: '/* eslint-disable */'
     config:
       avoidOptionals: true
+      dedupeOperationSuffix: true

--- a/packages/backend/package.json
+++ b/packages/backend/package.json
@@ -18,9 +18,8 @@
   "author": "MetaFam",
   "license": "ISC",
   "dependencies": {
-    "@ceramicnetwork/common": "1.8.0",
-    "@ceramicnetwork/http-client": "1.5.0",
-    "@ceramicnetwork/stream-caip10-link": "1.2.2",
+    "@ceramicnetwork/http-client": "1.5.7",
+    "@ceramicnetwork/stream-caip10-link": "1.2.9",
     "@datamodels/identity-accounts-web": "0.1.2",
     "@datamodels/identity-profile-basic": "0.1.2",
     "@glazed/datamodel": "0.2.0",
@@ -61,5 +60,7 @@
     "nock": "13.2.1",
     "ts-node-dev": "1.1.6"
   },
-  "resolutions": {}
+  "resolutions": {
+    "@ceramicnetwork/common": "1.11.0"
+  }
 }

--- a/packages/backend/src/handlers/actions/idxCache/updateSingle.ts
+++ b/packages/backend/src/handlers/actions/idxCache/updateSingle.ts
@@ -1,5 +1,4 @@
-import { CeramicApi } from '@ceramicnetwork/common';
-import Ceramic from '@ceramicnetwork/http-client';
+import { CeramicClient } from '@ceramicnetwork/http-client';
 import { Caip10Link } from '@ceramicnetwork/stream-caip10-link';
 import {
   Account,
@@ -52,7 +51,7 @@ export default async (playerId: string): Promise<UpdateIdxProfileResponse> => {
 
   try {
     const cache = new Map();
-    const ceramic = (new Ceramic(CONFIG.ceramicURL) as unknown) as CeramicApi;
+    const ceramic = new CeramicClient(CONFIG.ceramicURL);
     const loader = new TileLoader({ ceramic, cache });
     const manager = new ModelManager(ceramic);
     manager.addJSONModel(basicProfileModel);

--- a/packages/backend/src/handlers/triggers/syncDiscordGuildMembers.ts
+++ b/packages/backend/src/handlers/triggers/syncDiscordGuildMembers.ts
@@ -8,7 +8,7 @@ import { Request, Response } from 'express';
 import {
   Guild,
   Guild_Player_Insert_Input,
-  GuildFragmentFragment,
+  GuildFragment,
   GuildStatus_Enum,
   SyncGuildMembersMutation,
 } from '../../lib/autogen/hasura-sdk';
@@ -54,7 +54,7 @@ export const syncAllGuildDiscordMembers = async (
   }
 };
 
-const syncGuildMembers = async (guild: GuildFragmentFragment) => {
+const syncGuildMembers = async (guild: GuildFragment) => {
   if (guild?.discord_id == null) return;
 
   const getMetadataResponse = await client.GetGuildMetadataById({

--- a/packages/web/codegen.yml
+++ b/packages/web/codegen.yml
@@ -15,3 +15,5 @@ generates:
     config:
       gqlImport: fake-tag
       skipTypename: true
+      namingConvention:
+        transformUnderscore: true

--- a/packages/web/codegen.yml
+++ b/packages/web/codegen.yml
@@ -15,5 +15,11 @@ generates:
     config:
       gqlImport: fake-tag
       skipTypename: true
-      namingConvention:
-        transformUnderscore: true
+      dedupeOperationSuffix: true
+      documentMode: documentNode
+
+      # This generates typenames more in line with the rest
+      # of the codebase, but, unfortunately, player_role and
+      # PlayerRole create the same output name
+      # namingConvention:
+      #   transformUnderscore: true

--- a/packages/web/components/Dashboard/XP.tsx
+++ b/packages/web/components/Dashboard/XP.tsx
@@ -69,13 +69,13 @@ export const XP = (): React.ReactElement => {
         <Stat alignSelf="flex-start" justifySelf="flex-end" flex="0 0 100%">
           <StatLabel>All Time</StatLabel>
           <StatNumber>{userTotalXP.toLocaleString()}</StatNumber>
-          {user?.player?.rank && (
+          {user?.rank && (
             <MetaTag
-              backgroundColor={user.player.rank.toLowerCase()}
+              backgroundColor={user.rank.toLowerCase()}
               size="md"
               color="blackAlpha.600"
             >
-              {user.player.rank}
+              {user.rank}
             </MetaTag>
           )}
         </Stat>

--- a/packages/web/components/Guild/GuildForm.tsx
+++ b/packages/web/components/Guild/GuildForm.tsx
@@ -14,7 +14,7 @@ import { Field, FieldDescription } from 'components/Forms/Field';
 import { MetaLink } from 'components/Link';
 import {
   DiscordRole,
-  GuildFragmentFragment,
+  GuildFragment,
   GuildType_Enum,
   Maybe,
   useGetGuildMetadataQuery,
@@ -61,7 +61,7 @@ export interface EditGuildFormInputs {
 }
 
 const getDefaultFormValues = (
-  guild: GuildFragmentFragment,
+  guild: GuildFragment,
   metadata: GuildMetadata | undefined,
   roleOptions: SelectOption[],
 ): EditGuildFormInputs => {
@@ -95,7 +95,7 @@ const getDefaultFormValues = (
 };
 
 type Props = {
-  workingGuild: GuildFragmentFragment;
+  workingGuild: GuildFragment;
   onSubmit: (data: EditGuildFormInputs) => void;
   success?: boolean;
   submitting?: boolean;

--- a/packages/web/components/Guild/GuildHero.tsx
+++ b/packages/web/components/Guild/GuildHero.tsx
@@ -1,9 +1,9 @@
 import { Avatar, Box, MetaButton, Text, VStack } from '@metafam/ds';
 import { ProfileSection } from 'components/Profile/ProfileSection';
-import { GuildFragmentFragment } from 'graphql/autogen/types';
+import { GuildFragment } from 'graphql/autogen/types';
 import React from 'react';
 
-type Props = { guild: GuildFragmentFragment };
+type Props = { guild: GuildFragment };
 
 export const GuildHero: React.FC<Props> = ({ guild }) => (
   <ProfileSection>

--- a/packages/web/components/Guild/GuildJoin.tsx
+++ b/packages/web/components/Guild/GuildJoin.tsx
@@ -77,7 +77,7 @@ export const GuildJoin: React.FC = () => {
             </MetaLink>{' '}
             server.
           </Text>
-          {stateGuid?.length && user?.player ? (
+          {stateGuid?.length && user ? (
             <>
               <Text pt={4}>
                 Clicking the link below will redirect to a Discord page asking

--- a/packages/web/components/Guild/GuildLinks.tsx
+++ b/packages/web/components/Guild/GuildLinks.tsx
@@ -1,11 +1,11 @@
 import { IconButton, Wrap, WrapItem } from '@metafam/ds';
 import { ProfileSection } from 'components/Profile/ProfileSection';
-import { GuildFragmentFragment } from 'graphql/autogen/types';
+import { GuildFragment } from 'graphql/autogen/types';
 import React from 'react';
 import { FaDiscord, FaGithub, FaGlobe, FaTwitter } from 'react-icons/fa';
 
 type Props = {
-  guild: GuildFragmentFragment;
+  guild: GuildFragment;
 };
 
 export const GuildLinks: React.FC<Props> = ({ guild }) => (

--- a/packages/web/components/Guild/GuildList.tsx
+++ b/packages/web/components/Guild/GuildList.tsx
@@ -1,10 +1,10 @@
 import { SimpleGrid } from '@metafam/ds';
 import { GuildTile } from 'components/Guild/GuildTile';
-import { GuildFragmentFragment } from 'graphql/autogen/types';
+import { GuildFragment } from 'graphql/autogen/types';
 import React from 'react';
 
 type Props = {
-  guilds: GuildFragmentFragment[];
+  guilds: GuildFragment[];
 };
 
 export const GuildList: React.FC<Props> = ({ guilds }) => (

--- a/packages/web/components/Guild/GuildTile.tsx
+++ b/packages/web/components/Guild/GuildTile.tsx
@@ -12,12 +12,12 @@ import {
   Text,
   VStack,
 } from '@metafam/ds';
-import { GuildFragmentFragment } from 'graphql/autogen/types';
+import { GuildFragment } from 'graphql/autogen/types';
 import NextLink from 'next/link';
 import React from 'react';
 
 type Props = {
-  guild: GuildFragmentFragment;
+  guild: GuildFragment;
 };
 
 export const GuildTile: React.FC<Props> = ({ guild }) => (

--- a/packages/web/components/MegaMenu/MegaMenu.tsx
+++ b/packages/web/components/MegaMenu/MegaMenu.tsx
@@ -367,7 +367,6 @@ export const MegaMenu: React.FC = () => {
   const { connected, connect } = useWeb3();
   const router = useRouter();
   const { user, fetching } = useUser();
-  const { player } = user ?? {};
 
   const { isOpen, onOpen, onClose } = useDisclosure();
   const menuToggle = () => (isOpen ? onClose() : onOpen());
@@ -412,7 +411,7 @@ export const MegaMenu: React.FC = () => {
           w={{ base: 'fit-content', lg: '100%' }}
           justifyContent="space-between"
         >
-          <Logo link={user?.player ? '/dashboard' : '/'} />
+          <Logo link={user ? '/dashboard' : '/'} />
           <DesktopNavLinks />
           {/* <Search /> */}
           <Box
@@ -425,8 +424,8 @@ export const MegaMenu: React.FC = () => {
               <Spinner mr={4} />
             ) : (
               <>
-                {connected && !!player ? (
-                  <PlayerStats {...{ player }} />
+                {connected && !!user ? (
+                  <PlayerStats player={user} />
                 ) : (
                   <MetaButton
                     h="48px"

--- a/packages/web/components/MegaMenu/MegaMenu.tsx
+++ b/packages/web/components/MegaMenu/MegaMenu.tsx
@@ -327,8 +327,8 @@ const PlayerStats: React.FC<PlayerStatsProps> = ({ player }) => {
         >
           <PlayerAvatar
             {...{ player }}
-            w="52px"
-            h="52px"
+            w={14}
+            h={14}
             ml={4}
             _hover={{ transform: 'scale(0.9)' }}
           />

--- a/packages/web/components/MegaMenu/PlayerStatsBar.tsx
+++ b/packages/web/components/MegaMenu/PlayerStatsBar.tsx
@@ -53,7 +53,7 @@ export const PlayerStatsBar = () => {
               _active={{ bg: 'transparent' }}
             >
               <Flex>
-                <PlayerAvatar player={user} w={12} h={12} m={0} />
+                <PlayerAvatar player={user} w={14} h={14} m={0} />
                 <Stack my={2} ml={2} justify="center">
                   <Text
                     fontSize={user.rank ? 14 : 22}

--- a/packages/web/components/MegaMenu/PlayerStatsBar.tsx
+++ b/packages/web/components/MegaMenu/PlayerStatsBar.tsx
@@ -24,7 +24,6 @@ import { XPSeedsBalance } from './XPSeedsBalance';
 export const PlayerStatsBar = () => {
   const { disconnect } = useWeb3();
   const { user } = useUser();
-  const { player } = user ?? {};
 
   return (
     <Flex
@@ -33,7 +32,7 @@ export const PlayerStatsBar = () => {
       pos="fixed"
       left={0}
       bottom={0}
-      justify={player ? 'space-between' : 'center'}
+      justify={user ? 'space-between' : 'center'}
       w="100%"
       h="5rem"
       bg="rgba(0,0,0,0.75)"
@@ -41,7 +40,7 @@ export const PlayerStatsBar = () => {
       px="1rem"
       sx={{ backdropFilter: 'blur(10px)' }}
     >
-      {!player ? (
+      {!user ? (
         <LoginButton />
       ) : (
         <>
@@ -54,20 +53,20 @@ export const PlayerStatsBar = () => {
               _active={{ bg: 'transparent' }}
             >
               <Flex>
-                <PlayerAvatar {...{ player }} w={12} h={12} m={0} />
+                <PlayerAvatar player={user} w={12} h={12} m={0} />
                 <Stack my={2} ml={2} justify="center">
                   <Text
-                    fontSize={player.rank ? 14 : 22}
+                    fontSize={user.rank ? 14 : 22}
                     fontWeight="semibold"
                     m={0}
                     p={0}
                     lineHeight={1}
                   >
-                    {getPlayerName(player)}
+                    {getPlayerName(user)}
                   </Text>
-                  {player.rank && (
+                  {user.rank && (
                     <Text fontSize={12} m={0} p={0} lineHeight={1}>
-                      {player.rank}
+                      {user.rank}
                     </Text>
                   )}
                 </Stack>
@@ -76,7 +75,7 @@ export const PlayerStatsBar = () => {
             <MenuList color="black">
               <MetaLink
                 color="black"
-                href={getPlayerURL(player) ?? '/'}
+                href={getPlayerURL(user) ?? '/'}
                 _hover={{ textDecoration: 'none' }}
               >
                 <MenuItem>
@@ -100,7 +99,7 @@ export const PlayerStatsBar = () => {
             </MenuList>
           </Menu>
           <HStack justify="flex-end">
-            <XPSeedsBalance totalXP={player.totalXP} mobile />
+            <XPSeedsBalance totalXP={user.totalXP} mobile />
           </HStack>
         </>
       )}

--- a/packages/web/components/Player/PlayerContacts.tsx
+++ b/packages/web/components/Player/PlayerContacts.tsx
@@ -1,5 +1,5 @@
 import { Button, Tooltip, Wrap, WrapItem } from '@metafam/ds';
-import { PlayerFragmentFragment } from 'graphql/autogen/types';
+import { Player } from 'graphql/autogen/types';
 import { useCopyToClipboard } from 'lib/hooks/useCopyToClipboard';
 import React from 'react';
 import { FaEthereum, FaGithub, FaTwitter } from 'react-icons/fa';
@@ -8,7 +8,7 @@ import { formatAddress } from 'utils/playerHelpers';
 import { PlayerBrightId } from './Section/PlayerBrightId';
 
 type Props = {
-  player: PlayerFragmentFragment;
+  player: Player;
   disableBrightId?: boolean;
 };
 

--- a/packages/web/components/Player/PlayerTileMemberships.tsx
+++ b/packages/web/components/Player/PlayerTileMemberships.tsx
@@ -1,9 +1,9 @@
 import { MetaTag, Text, VStack, Wrap, WrapItem } from '@metafam/ds';
-import { PlayerFragmentFragment } from 'graphql/autogen/types';
+import { Player } from 'graphql/autogen/types';
 import React, { useMemo } from 'react';
 
 type Props = {
-  player: PlayerFragmentFragment;
+  player: Player;
 };
 
 const SHOW_MEMBERSHIPS = 4;

--- a/packages/web/components/Player/Section/PlayerAchievements.tsx
+++ b/packages/web/components/Player/Section/PlayerAchievements.tsx
@@ -1,13 +1,13 @@
 import { HStack, Text } from '@metafam/ds';
 import { ProfileSection } from 'components/Profile/ProfileSection';
-import { PlayerFragmentFragment } from 'graphql/autogen/types';
+import { Player } from 'graphql/autogen/types';
 import React from 'react';
 import { FaMedal } from 'react-icons/fa';
 import { BoxType } from 'utils/boxTypes';
 
 // TODO Fake data
 type Props = {
-  player: PlayerFragmentFragment;
+  player: Player;
   isOwnProfile?: boolean;
   canEdit?: boolean;
 };

--- a/packages/web/components/Player/Section/PlayerAddSection.tsx
+++ b/packages/web/components/Player/Section/PlayerAddSection.tsx
@@ -17,13 +17,13 @@ import {
 import { Maybe } from '@metafam/utils';
 import BackgroundImage from 'assets/main-background.jpg';
 import { PlayerSection } from 'components/Profile/PlayerSection';
-import { PlayerFragmentFragment } from 'graphql/autogen/types';
+import { Player } from 'graphql/autogen/types';
 import { PersonalityInfo } from 'graphql/queries/enums/getPersonalityInfo';
 import React, { useCallback, useEffect, useState } from 'react';
 import { BoxMetadata, BoxType } from 'utils/boxTypes';
 
 type Props = FlexProps & {
-  player: PlayerFragmentFragment;
+  player: Player;
   personalityInfo: PersonalityInfo;
   boxList: BoxType[];
   onAddBox: (arg0: BoxType, arg1: BoxMetadata) => void;

--- a/packages/web/components/Player/Section/PlayerBrightId.tsx
+++ b/packages/web/components/Player/Section/PlayerBrightId.tsx
@@ -14,14 +14,14 @@ import {
   useDisclosure,
   VStack,
 } from '@metafam/ds';
-import { PlayerFragmentFragment } from 'graphql/autogen/types';
+import { Player } from 'graphql/autogen/types';
 import { useUser, useWeb3 } from 'lib/hooks';
 import { useBrightIdStatus, useBrightIdUpdated } from 'lib/hooks/brightId';
 import React, { useEffect, useState } from 'react';
 import { QRCode } from 'react-qr-svg';
 import { isBackdropFilterSupported } from 'utils/compatibilityHelpers';
 
-type Props = { player: PlayerFragmentFragment };
+type Props = { player: Player };
 
 export const PlayerBrightId: React.FC<Props> = ({ player }) => {
   const { isOpen, onOpen, onClose } = useDisclosure();

--- a/packages/web/components/Player/Section/PlayerColorDisposition.tsx
+++ b/packages/web/components/Player/Section/PlayerColorDisposition.tsx
@@ -2,14 +2,14 @@ import { Link, Text } from '@metafam/ds';
 import { FlexContainer } from 'components/Container';
 import { ColorBar } from 'components/Player/ColorBar';
 import { ProfileSection } from 'components/Profile/ProfileSection';
-import { PlayerFragmentFragment } from 'graphql/autogen/types';
+import { Player } from 'graphql/autogen/types';
 import { PersonalityInfo } from 'graphql/queries/enums/getPersonalityInfo';
 import { useAnimateProfileChanges } from 'lib/hooks/players';
 import React, { useState } from 'react';
 import { BoxType } from 'utils/boxTypes';
 
 type Props = {
-  player: PlayerFragmentFragment;
+  player: Player;
   personalityInfo: PersonalityInfo;
   isOwnProfile?: boolean;
   canEdit?: boolean;

--- a/packages/web/components/Player/Section/PlayerCompletedQuests.tsx
+++ b/packages/web/components/Player/Section/PlayerCompletedQuests.tsx
@@ -2,7 +2,7 @@ import { Box, Button, ExternalLinkIcon, Link, Stack, Text } from '@metafam/ds';
 import { ProfileSection } from 'components/Profile/ProfileSection';
 import {
   Player,
-  QuestCompletionFragmentFragment,
+  QuestCompletionFragment,
   QuestCompletionStatus_Enum,
 } from 'graphql/autogen/types';
 import { getAcceptedQuestsByPlayerQuery } from 'graphql/getQuests';
@@ -20,9 +20,7 @@ export const PlayerCompletedQuests: React.FC<Props> = ({
   isOwnProfile,
   canEdit,
 }) => {
-  const [quests, setQuests] = useState<Array<QuestCompletionFragmentFragment>>(
-    [],
-  );
+  const [quests, setQuests] = useState<Array<QuestCompletionFragment>>([]);
 
   useEffect(() => {
     const loadQuests = async () => {
@@ -68,7 +66,7 @@ export const PlayerCompletedQuests: React.FC<Props> = ({
 };
 
 interface QuestProps {
-  quests: Array<QuestCompletionFragmentFragment>;
+  quests: Array<QuestCompletionFragment>;
   mb?: number;
 }
 

--- a/packages/web/components/Player/Section/PlayerCompletedQuests.tsx
+++ b/packages/web/components/Player/Section/PlayerCompletedQuests.tsx
@@ -1,7 +1,7 @@
 import { Box, Button, ExternalLinkIcon, Link, Stack, Text } from '@metafam/ds';
 import { ProfileSection } from 'components/Profile/ProfileSection';
 import {
-  PlayerFragmentFragment,
+  Player,
   QuestCompletionFragmentFragment,
   QuestCompletionStatus_Enum,
 } from 'graphql/autogen/types';
@@ -10,7 +10,7 @@ import React, { useEffect, useState } from 'react';
 import { BoxType } from 'utils/boxTypes';
 
 type Props = {
-  player: PlayerFragmentFragment;
+  player: Player;
   isOwnProfile?: boolean;
   canEdit?: boolean;
 };

--- a/packages/web/components/Player/Section/PlayerGallery.tsx
+++ b/packages/web/components/Player/Section/PlayerGallery.tsx
@@ -14,7 +14,7 @@ import {
 } from '@metafam/ds';
 import { MetaLink as Link } from 'components/Link';
 import { ProfileSection } from 'components/Profile/ProfileSection';
-import { PlayerFragmentFragment } from 'graphql/autogen/types';
+import { Player } from 'graphql/autogen/types';
 import { Collectible, useOpenSeaCollectibles } from 'lib/hooks/opensea';
 import React from 'react';
 import { BoxType } from 'utils/boxTypes';
@@ -53,7 +53,7 @@ const GalleryItem: React.FC<{ nft: Collectible; noMargin?: boolean }> = ({
 );
 
 type Props = {
-  player: PlayerFragmentFragment;
+  player: Player;
   isOwnProfile?: boolean;
   canEdit?: boolean;
 };

--- a/packages/web/components/Player/Section/PlayerHero.tsx
+++ b/packages/web/components/Player/Section/PlayerHero.tsx
@@ -69,7 +69,7 @@ export const PlayerHero: React.FC<Props> = ({
   const [playerName, setPlayerName] = useState<string>();
   const { user } = useUser();
 
-  const person = isOwnProfile ? user?.player : player;
+  const person = isOwnProfile ? user : player;
   useEffect(() => {
     if (person) {
       setPlayerName(getPlayerName(person));

--- a/packages/web/components/Player/Section/PlayerHero.tsx
+++ b/packages/web/components/Player/Section/PlayerHero.tsx
@@ -27,7 +27,7 @@ import { PlayerContacts } from 'components/Player/PlayerContacts';
 import { PlayerHeroTile } from 'components/Player/Section/PlayerHeroTile';
 import { PlayerPronouns } from 'components/Player/Section/PlayerPronouns';
 import { ProfileSection } from 'components/Profile/ProfileSection';
-import { PlayerFragmentFragment } from 'graphql/autogen/types';
+import { Player } from 'graphql/autogen/types';
 import { Maybe } from 'graphql/jsutils/Maybe';
 import { PersonalityInfo } from 'graphql/queries/enums/getPersonalityInfo';
 import { useUser } from 'lib/hooks';
@@ -42,17 +42,17 @@ import { ColorBar } from '../ColorBar';
 const MAX_BIO_LENGTH = 240;
 
 type Props = {
-  player: PlayerFragmentFragment;
+  player: Player;
   personalityInfo: PersonalityInfo;
   isOwnProfile?: boolean;
   canEdit?: boolean;
 };
-type AvailabilityProps = { person?: Maybe<PlayerFragmentFragment> };
+type AvailabilityProps = { person?: Maybe<Player> };
 type TimeZoneDisplayProps = {
-  person?: Maybe<PlayerFragmentFragment>;
+  person?: Maybe<Player>;
 };
 type ColorDispositionProps = {
-  person?: Maybe<PlayerFragmentFragment>;
+  person?: Maybe<Player>;
   personalityInfo: PersonalityInfo;
 };
 

--- a/packages/web/components/Player/Section/PlayerMemberships.tsx
+++ b/packages/web/components/Player/Section/PlayerMemberships.tsx
@@ -19,7 +19,7 @@ import {
   LinkGuild,
 } from 'components/Player/PlayerGuild';
 import { ProfileSection } from 'components/Profile/ProfileSection';
-import { PlayerFragmentFragment } from 'graphql/autogen/types';
+import { Player } from 'graphql/autogen/types';
 import { getAllMemberships, GuildMembership } from 'graphql/getMemberships';
 import React, { useEffect, useMemo, useState } from 'react';
 import { BoxType } from 'utils/boxTypes';
@@ -105,7 +105,7 @@ const DaoListing: React.FC<DaoListingProps> = ({ membership }) => {
 };
 
 type MembershipSectionProps = {
-  player: PlayerFragmentFragment;
+  player: Player;
   isOwnProfile?: boolean;
   canEdit?: boolean;
 };

--- a/packages/web/components/Player/Section/PlayerPronouns.tsx
+++ b/packages/web/components/Player/Section/PlayerPronouns.tsx
@@ -1,11 +1,11 @@
 import { MetaTag } from '@metafam/ds';
 import { FlexContainer } from 'components/Container';
 import { PlayerHeroTile } from 'components/Player/Section/PlayerHeroTile';
-import { PlayerFragmentFragment } from 'graphql/autogen/types';
+import { Player } from 'graphql/autogen/types';
 import { useAnimateProfileChanges } from 'lib/hooks/players';
 import React, { useState } from 'react';
 
-type Props = { person: PlayerFragmentFragment | null | undefined };
+type Props = { person: Player | null | undefined };
 
 export const PlayerPronouns: React.FC<Props> = ({ person }) => {
   const [pronouns, setPronouns] = useState<string>(

--- a/packages/web/components/Player/Section/PlayerRoles.tsx
+++ b/packages/web/components/Player/Section/PlayerRoles.tsx
@@ -1,11 +1,11 @@
 import { BoxedNextImage, MetaTag, Text, Wrap } from '@metafam/ds';
 import { ProfileSection } from 'components/Profile/ProfileSection';
-import { PlayerFragmentFragment } from 'graphql/autogen/types';
+import { Player } from 'graphql/autogen/types';
 import React from 'react';
 import { BoxType } from 'utils/boxTypes';
 
 type Props = {
-  player: PlayerFragmentFragment;
+  player: Player;
   isOwnProfile?: boolean;
   canEdit?: boolean;
 };

--- a/packages/web/components/Player/Section/PlayerSkills.tsx
+++ b/packages/web/components/Player/Section/PlayerSkills.tsx
@@ -1,16 +1,13 @@
 import { MetaTag, Text, Wrap, WrapItem } from '@metafam/ds';
 import { ProfileSection } from 'components/Profile/ProfileSection';
-import {
-  PlayerFragmentFragment,
-  SkillCategory_Enum,
-} from 'graphql/autogen/types';
+import { Player, SkillCategory_Enum } from 'graphql/autogen/types';
 import { SkillColors } from 'graphql/types';
 import { useAnimateProfileChanges } from 'lib/hooks/players';
 import React, { useState } from 'react';
 import { BoxType } from 'utils/boxTypes';
 
 type Props = {
-  player: PlayerFragmentFragment;
+  player: Player;
   isOwnProfile?: boolean;
   canEdit?: boolean;
 };

--- a/packages/web/components/Player/Section/PlayerType.tsx
+++ b/packages/web/components/Player/Section/PlayerType.tsx
@@ -1,13 +1,13 @@
 import { Text } from '@metafam/ds';
 import { FlexContainer } from 'components/Container';
 import { ProfileSection } from 'components/Profile/ProfileSection';
-import { ExplorerType, PlayerFragmentFragment } from 'graphql/autogen/types';
+import { ExplorerType, Player } from 'graphql/autogen/types';
 import { useAnimateProfileChanges } from 'lib/hooks/players';
 import React, { useState } from 'react';
 import { BoxType } from 'utils/boxTypes';
 
 type Props = {
-  player: PlayerFragmentFragment;
+  player: Player;
   isOwnProfile?: boolean;
   canEdit?: boolean;
 };

--- a/packages/web/components/Profile/PlayerSection.tsx
+++ b/packages/web/components/Profile/PlayerSection.tsx
@@ -9,7 +9,7 @@ import { PlayerRoles } from 'components/Player/Section/PlayerRoles';
 import { PlayerSkills } from 'components/Player/Section/PlayerSkills';
 import { PlayerType } from 'components/Player/Section/PlayerType';
 import { EmbeddedUrl } from 'components/Profile/EmbeddedUrlSection';
-import { PlayerFragmentFragment } from 'graphql/autogen/types';
+import { Player } from 'graphql/autogen/types';
 import { PersonalityInfo } from 'graphql/queries/enums/getPersonalityInfo';
 import React from 'react';
 import { FaTimes } from 'react-icons/fa';
@@ -18,7 +18,7 @@ import { BoxMetadata, BoxType, getBoxKey } from 'utils/boxTypes';
 type Props = {
   boxType: BoxType;
   boxMetadata: BoxMetadata;
-  player: PlayerFragmentFragment;
+  player: Player;
   personalityInfo: PersonalityInfo;
   isOwnProfile?: boolean;
   canEdit?: boolean;

--- a/packages/web/components/Quest/CompletionForm.tsx
+++ b/packages/web/components/Quest/CompletionForm.tsx
@@ -9,7 +9,7 @@ import {
 } from '@metafam/ds';
 import {
   CreateQuestCompletionInput,
-  QuestFragmentFragment,
+  QuestFragment,
 } from 'graphql/autogen/types';
 import { useRouter } from 'next/router';
 import React, { useState } from 'react';
@@ -17,7 +17,7 @@ import { useForm } from 'react-hook-form';
 import { URIRegexp } from 'utils/questHelpers';
 
 type Props = {
-  quest: QuestFragmentFragment;
+  quest: QuestFragment;
   onSubmit: (data: CreateQuestCompletionInput) => void;
   success?: boolean;
   fetching?: boolean;

--- a/packages/web/components/Quest/QuestCompletions.tsx
+++ b/packages/web/components/Quest/QuestCompletions.tsx
@@ -14,7 +14,7 @@ import {
   Quest,
   QuestCompletionStatus_ActionEnum,
   QuestCompletionStatus_Enum,
-  QuestWithCompletionFragmentFragment,
+  QuestWithCompletionFragment,
   useUpdateQuestCompletionMutation,
 } from 'graphql/autogen/types';
 import { useUser } from 'lib/hooks';
@@ -31,7 +31,7 @@ interface AlertSubmission {
 }
 
 type Props = {
-  quest: QuestWithCompletionFragmentFragment;
+  quest: QuestWithCompletionFragment;
 };
 
 export const QuestCompletions: React.FC<Props> = ({ quest }) => {

--- a/packages/web/components/Quest/QuestCompletions.tsx
+++ b/packages/web/components/Quest/QuestCompletions.tsx
@@ -21,7 +21,7 @@ import { useUser } from 'lib/hooks';
 import moment from 'moment';
 import React, { useCallback, useState } from 'react';
 import { FaExternalLinkAlt } from 'react-icons/fa';
-import { getPlayerName } from 'utils/playerHelpers';
+import { getPlayerName, getPlayerURL } from 'utils/playerHelpers';
 
 import { CompletionStatusTag } from './QuestTags';
 
@@ -99,7 +99,7 @@ export const QuestCompletions: React.FC<Props> = ({ quest }) => {
                   <i>
                     by{' '}
                     <MetaLink
-                      as={`/player/${player.profile?.username}`}
+                      as={getPlayerURL(player)}
                       href="/player/[username]"
                     >
                       {getPlayerName(player as Player)}

--- a/packages/web/components/Quest/QuestDetails.tsx
+++ b/packages/web/components/Quest/QuestDetails.tsx
@@ -17,7 +17,7 @@ import {
   Quest,
   QuestRepetition_Enum,
   QuestStatus_Enum,
-  QuestWithCompletionFragmentFragment,
+  QuestWithCompletionFragment,
   Skill,
 } from 'graphql/autogen/types';
 import parse from 'html-react-parser';
@@ -31,7 +31,7 @@ import { SkillsTags } from '../Skills';
 import { RepetitionTag, StatusTag } from './QuestTags';
 
 type Props = {
-  quest: QuestWithCompletionFragmentFragment;
+  quest: QuestWithCompletionFragment;
 };
 
 export const QuestDetails: React.FC<Props> = ({ quest }) => {

--- a/packages/web/components/Quest/QuestFilter.tsx
+++ b/packages/web/components/Quest/QuestFilter.tsx
@@ -12,7 +12,7 @@ import {
   GetQuestsQueryVariables,
   Order_By,
   PlayerRole,
-  QuestFragmentFragment,
+  QuestFragment,
   QuestStatus_Enum,
 } from 'graphql/autogen/types';
 import React, { useState } from 'react';
@@ -21,7 +21,7 @@ import { useUser } from '../../lib/hooks';
 import { QueryVariableSetter, QuestAggregates } from '../../lib/hooks/quests';
 
 type Props = {
-  quests: QuestFragmentFragment[];
+  quests: QuestFragment[];
   aggregates: QuestAggregates;
   queryVariables: GetQuestsQueryVariables;
   setQueryVariable: QueryVariableSetter;

--- a/packages/web/components/Quest/QuestForm.tsx
+++ b/packages/web/components/Quest/QuestForm.tsx
@@ -11,9 +11,9 @@ import {
   VStack,
 } from '@metafam/ds';
 import {
-  GuildFragmentFragment,
+  GuildFragment,
   PlayerRole,
-  QuestFragmentFragment,
+  QuestFragment,
   QuestRepetition_Enum,
   QuestStatus_Enum,
 } from 'graphql/autogen/types';
@@ -70,8 +70,8 @@ export interface CreateQuestFormInputs {
 const MetaFamGuildId = 'f94b7cd4-cf29-4251-baa5-eaacab98a719';
 
 const getDefaultFormValues = (
-  base: QuestFragmentFragment | undefined,
-  guilds: GuildFragmentFragment[],
+  base: QuestFragment | undefined,
+  guilds: GuildFragment[],
 ): CreateQuestFormInputs => ({
   title: base?.title || '',
   repetition: base?.repetition ?? QuestRepetition_Enum.Unique,
@@ -127,8 +127,8 @@ const Field: React.FC<FieldProps> = ({ children, error, label }) => (
 );
 
 type Props = {
-  guilds: GuildFragmentFragment[];
-  editQuest?: QuestFragmentFragment;
+  guilds: GuildFragment[];
+  editQuest?: QuestFragment;
   skillChoices: Array<CategoryOption>;
   roleChoices: Array<PlayerRole>;
   onSubmit: (data: CreateQuestFormInputs) => void;

--- a/packages/web/components/Quest/QuestList.tsx
+++ b/packages/web/components/Quest/QuestList.tsx
@@ -1,10 +1,10 @@
 import { Box, SimpleGrid, Text } from '@metafam/ds';
 import { QuestTile } from 'components/Quest/QuestTile';
-import { QuestFragmentFragment } from 'graphql/autogen/types';
+import { QuestFragment } from 'graphql/autogen/types';
 import React from 'react';
 
 type Props = {
-  quests: QuestFragmentFragment[];
+  quests: QuestFragment[];
 };
 
 /* TODO

--- a/packages/web/components/Quest/QuestTile.tsx
+++ b/packages/web/components/Quest/QuestTile.tsx
@@ -12,11 +12,7 @@ import {
 } from '@metafam/ds';
 import BackgroundImage from 'assets/main-background.jpg';
 import { MetaLink } from 'components/Link';
-import {
-  PlayerRole,
-  QuestFragmentFragment,
-  Skill,
-} from 'graphql/autogen/types';
+import { PlayerRole, QuestFragment, Skill } from 'graphql/autogen/types';
 import parse from 'html-react-parser';
 import moment from 'moment';
 import React from 'react';
@@ -26,7 +22,7 @@ import { SkillsTags } from '../Skills';
 import { RepetitionTag, StatusTag } from './QuestTags';
 
 type Props = {
-  quest: QuestFragmentFragment;
+  quest: QuestFragment;
 };
 
 export const QuestTile: React.FC<Props> = ({ quest }) => (

--- a/packages/web/components/Setup/SetupDone.tsx
+++ b/packages/web/components/Setup/SetupDone.tsx
@@ -19,7 +19,7 @@ export const SetupDone: React.FC = () => {
         justify="center"
         align="center"
       >
-        {user?.player && <PlayerTile player={user.player} />}
+        {user && <PlayerTile player={user} />}
         <MetaButton
           onClick={() => {
             setLoading(true);

--- a/packages/web/components/Setup/SetupPersonalityType.tsx
+++ b/packages/web/components/Setup/SetupPersonalityType.tsx
@@ -42,7 +42,6 @@ export const SetupPersonalityType: React.FC<SetupPersonalityTypeProps> = ({
 }) => {
   const { onNextPress, nextButtonLabel } = useSetupFlow();
   const { fetching: fetchingUser, user } = useUser();
-  const { player } = user ?? {};
   const { ceramic } = useWeb3();
   const toast = useToast();
   const [status, setStatus] = useState<Maybe<ReactElement | string>>(null);
@@ -51,10 +50,10 @@ export const SetupPersonalityType: React.FC<SetupPersonalityTypeProps> = ({
   const isWizard = !isEdit;
 
   useEffect(() => {
-    if (player?.profile?.colorMask != null) {
-      setColorMask(player.profile.colorMask);
+    if (user?.profile?.colorMask != null) {
+      setColorMask(user.profile.colorMask);
     }
-  }, [colorMask, player]);
+  }, [colorMask, user]);
 
   const [fetchingInfo, setFetchingInfo] = useState(true);
 
@@ -92,7 +91,7 @@ export const SetupPersonalityType: React.FC<SetupPersonalityTypeProps> = ({
       return;
     }
 
-    if (user.player?.profile?.colorMask !== colorMask) {
+    if (user.profile?.colorMask !== colorMask) {
       try {
         if (!ceramic.did?.authenticated) {
           setStatus(<Text>Authenticating DID…</Text>);

--- a/packages/web/components/Setup/SetupPlayerType.tsx
+++ b/packages/web/components/Setup/SetupPlayerType.tsx
@@ -31,7 +31,6 @@ export type Props = {
 export const SetupPlayerType: React.FC<Props> = ({ isEdit, onClose }) => {
   const { onNextPress, nextButtonLabel } = useSetupFlow();
   const { user } = useUser();
-  const { player } = user ?? {};
   const { ceramic } = useWeb3();
   const toast = useToast();
   const [status, setStatus] = useState<Maybe<ReactElement | string>>(null);
@@ -40,13 +39,13 @@ export const SetupPlayerType: React.FC<Props> = ({ isEdit, onClose }) => {
   const isWizard = !isEdit;
 
   const load = () => {
-    if (player) {
-      if (explorerType === undefined && player.profile?.explorerType != null) {
-        setExplorerType(player.profile.explorerType);
+    if (user) {
+      if (explorerType === undefined && user.profile?.explorerType != null) {
+        setExplorerType(user.profile.explorerType);
       }
     }
   };
-  useEffect(load, [explorerType, player, player?.profile?.explorerType]);
+  useEffect(load, [explorerType, user, user?.profile?.explorerType]);
 
   useEffect(() => {
     const fetchTypes = async () => {
@@ -76,7 +75,7 @@ export const SetupPlayerType: React.FC<Props> = ({ isEdit, onClose }) => {
       return;
     }
 
-    if (player?.profile?.explorerType?.id !== explorerType?.id) {
+    if (user?.profile?.explorerType?.id !== explorerType?.id) {
       try {
         if (!ceramic.did?.authenticated) {
           setStatus('Authenticating DID…');

--- a/packages/web/components/Setup/SetupRoles.tsx
+++ b/packages/web/components/Setup/SetupRoles.tsx
@@ -64,7 +64,7 @@ export const SetupRoles: React.FC<SetupRolesProps> = ({
   ]);
   const [roles, setRoles] = useState<string[]>([]);
   useEffect(() => {
-    setRoles(user?.player?.roles.map((r) => r.role) ?? []);
+    setRoles(user?.roles.map((r) => r.role) ?? []);
   }, [user]);
 
   const availableRoles = useMemo(

--- a/packages/web/components/Setup/SetupSkills.tsx
+++ b/packages/web/components/Setup/SetupSkills.tsx
@@ -77,17 +77,12 @@ export const SetupSkills: React.FC<SetupSkillsProps> = ({
   const [loading, setLoading] = useState(false);
   const [playerSkills, setPlayerSkills] = useState<Array<SkillOption>>([]);
   const isWizard = !isEdit;
-  const { player } = user ?? {};
 
   useEffect(() => {
-    if (player) {
-      if (
-        player.skills &&
-        player.skills.length > 0 &&
-        playerSkills.length === 0
-      ) {
+    if (user) {
+      if (user.skills && user.skills.length > 0 && playerSkills.length === 0) {
         setPlayerSkills(
-          player.skills.map(({ Skill: skill }) => ({
+          user.skills.map(({ Skill: skill }) => ({
             value: skill.id,
             label: skill.name,
             ...skill,
@@ -112,7 +107,7 @@ export const SetupSkills: React.FC<SetupSkillsProps> = ({
     setLoading(true);
 
     const { error } = await updateSkills({
-      skills: playerSkills.map((s) => ({ skill_id: s.id })),
+      skills: playerSkills.map(({ id }) => ({ skill_id: id })),
     });
 
     if (error) {

--- a/packages/web/components/Setup/SetupTimeZone.tsx
+++ b/packages/web/components/Setup/SetupTimeZone.tsx
@@ -15,10 +15,9 @@ export const SetupTimeZone: React.FC = () => {
   const [loading, setLoading] = useState(false);
 
   useEffect(() => {
-    if (user?.player) {
-      const { player } = user;
-      if (player.profile?.timeZone && !timeZone) {
-        setTimeZone(player.profile.timeZone);
+    if (user) {
+      if (user.profile?.timeZone && !timeZone) {
+        setTimeZone(user.profile.timeZone);
       }
     }
   }, [user, timeZone]);

--- a/packages/web/contexts/Web3Context.tsx
+++ b/packages/web/contexts/Web3Context.tsx
@@ -101,10 +101,7 @@ export const Web3ContextProvider: React.FC<Web3ContextProviderOptions> = ({
   const [connecting, setConnecting] = useState(!!web3Modal?.cachedProvider);
   const [address, setAddress] = useState<Maybe<string>>(null);
   const [authToken, setAuthToken] = useState<Maybe<string>>(null);
-  const ceramic = useMemo(
-    () => (new CeramicClient(CONFIG.ceramicURL) as unknown) as CeramicApi,
-    [],
-  );
+  const ceramic = useMemo(() => new CeramicClient(CONFIG.ceramicURL), []);
 
   useEffect(() => {
     if (wallet && address) {

--- a/packages/web/graphql/fragments.ts
+++ b/packages/web/graphql/fragments.ts
@@ -1,6 +1,4 @@
-import gql from 'fake-tag';
-
-export const PlayerFragment = gql`
+export const PlayerFragment = /* GraphQL */ `
   fragment PlayerFragment on player {
     id @skip(if: $forLoginDisplay)
     totalXP @skip(if: $forLoginDisplay)
@@ -74,7 +72,7 @@ export const PlayerFragment = gql`
   }
 `;
 
-export const GuildFragment = gql`
+export const GuildFragment = /* GraphQL */ `
   fragment GuildFragment on guild {
     id
     guildname
@@ -92,7 +90,7 @@ export const GuildFragment = gql`
   }
 `;
 
-export const QuestFragment = gql`
+export const QuestFragment = /* GraphQL */ `
   fragment QuestFragment on quest {
     id
     createdAt
@@ -130,7 +128,7 @@ export const QuestFragment = gql`
   }
 `;
 
-export const QuestWithCompletionFragment = gql`
+export const QuestWithCompletionFragment = /* GraphQL */ `
   fragment QuestWithCompletionFragment on quest {
     id
     createdAt
@@ -174,7 +172,7 @@ export const QuestWithCompletionFragment = gql`
   }
 `;
 
-export const QuestCompletionFragment = gql`
+export const QuestCompletionFragment = /* GraphQL */ `
   fragment QuestCompletionFragment on quest_completion {
     id
     completedByPlayerId
@@ -189,14 +187,14 @@ export const QuestCompletionFragment = gql`
   }
 `;
 
-export const TokenBalancesFragment = gql`
+export const TokenBalancesFragment = /* GraphQL */ `
   fragment TokenBalancesFragment on TokenBalances {
     address: id
     pSeedBalance
   }
 `;
 
-export const PlayerSkillFragment = gql`
+export const PlayerSkillFragment = /* GraphQL */ `
   fragment PlayerSkillFragment on skill {
     id
     name

--- a/packages/web/graphql/getMe.ts
+++ b/packages/web/graphql/getMe.ts
@@ -1,7 +1,6 @@
-import gql from 'fake-tag';
 import { PlayerFragment } from 'graphql/fragments';
 
-export const GetMeQuery = gql`
+export const GetMeQuery = /* GraphQL */ `
   query GetMe($forLoginDisplay: Boolean! = false) {
     me {
       id

--- a/packages/web/graphql/getMe.ts
+++ b/packages/web/graphql/getMe.ts
@@ -3,10 +3,7 @@ import { PlayerFragment } from 'graphql/fragments';
 export const GetMeQuery = /* GraphQL */ `
   query GetMe($forLoginDisplay: Boolean! = false) {
     me {
-      id
-      ethereumAddress
-      username
-      player {
+      record: player {
         ...PlayerFragment
       }
     }

--- a/packages/web/graphql/getMemberships.ts
+++ b/packages/web/graphql/getMemberships.ts
@@ -1,15 +1,13 @@
-import gql from 'fake-tag';
-
 import {
   GetDaoMembershipsQuery,
   GetDaoMembershipsQueryVariables,
   GetPlayerGuildsQuery,
   GetPlayerGuildsQueryVariables,
-  PlayerFragmentFragment,
+  Player,
 } from './autogen/types';
 import { client } from './client';
 
-const daoMembershipsQuery = gql`
+const daoMembershipsQuery = /* GraphQL */ `
   query GetDaoMemberships($address: String) {
     getDaoHausMemberships(memberAddress: $address) {
       id
@@ -23,7 +21,7 @@ const daoMembershipsQuery = gql`
   }
 `;
 
-const guildMembershipsQuery = gql`
+const guildMembershipsQuery = /* GraphQL */ `
   query GetPlayerGuilds($playerId: uuid!) {
     guild_player(where: { player_id: { _eq: $playerId } }) {
       guild_id
@@ -80,7 +78,7 @@ export type GuildMembership = {
   guildname?: string;
 };
 
-export const getAllMemberships = async (player: PlayerFragmentFragment) => {
+export const getAllMemberships = async (player: Player) => {
   const guildPlayers = await getGuildMemberships(player.id);
 
   const daohausMemberships = player.daohausMemberships?.filter(

--- a/packages/web/graphql/getPatrons.ts
+++ b/packages/web/graphql/getPatrons.ts
@@ -1,11 +1,9 @@
-import gql from 'fake-tag';
-
 import {
   GetPatronsQuery,
   GetPatronsQueryVariables,
   GetpSeedHoldersQuery,
   GetpSeedHoldersQueryVariables,
-  PlayerFragmentFragment,
+  Player,
   TokenBalancesFragmentFragment,
 } from './autogen/types';
 import { client } from './client';
@@ -13,7 +11,7 @@ import { PlayerFragment, TokenBalancesFragment } from './fragments';
 import { Patron } from './types';
 
 // eslint-disable-next-line @typescript-eslint/no-unused-expressions
-gql`
+/* GraphQL */ `
   query GetpSeedBalance($address: String!) {
     getTokenBalances(address: $address) {
       ...TokenBalancesFragment
@@ -22,7 +20,7 @@ gql`
   ${TokenBalancesFragment}
 `;
 
-const patronsQuery = gql`
+const patronsQuery = /* GraphQL */ `
   query GetPatrons(
     $addresses: [String!]
     $limit: Int
@@ -35,7 +33,7 @@ const patronsQuery = gql`
   ${PlayerFragment}
 `;
 
-const pSeedHoldersQuery = gql`
+const pSeedHoldersQuery = /* GraphQL */ `
   query GetpSeedHolders($limit: Int) {
     pSeedHolders: getTopPSeedHolders(limit: $limit) {
       ...TokenBalancesFragment
@@ -47,7 +45,7 @@ const pSeedHoldersQuery = gql`
 const getPlayersFromAddresses = async (
   addresses: Array<string>,
   limit: number,
-): Promise<Array<PlayerFragmentFragment>> => {
+): Promise<Array<Player>> => {
   const { data, error } = await client
     .query<GetPatronsQuery, GetPatronsQueryVariables>(patronsQuery, {
       addresses,
@@ -62,7 +60,7 @@ const getPlayersFromAddresses = async (
     return [];
   }
 
-  return data.player;
+  return data.player as Array<Player>;
 };
 
 const getpSeedHolders = async (
@@ -90,7 +88,7 @@ export const getPatrons = async (limit = 50): Promise<Array<Patron>> => {
     limit,
   );
 
-  const players: Array<PlayerFragmentFragment> = await getPlayersFromAddresses(
+  const players: Array<Player> = await getPlayersFromAddresses(
     tokenBalances.map(({ address }) => address),
     limit,
   );

--- a/packages/web/graphql/getPatrons.ts
+++ b/packages/web/graphql/getPatrons.ts
@@ -4,11 +4,11 @@ import {
   GetpSeedHoldersQuery,
   GetpSeedHoldersQueryVariables,
   Player,
-  TokenBalancesFragmentFragment,
-} from './autogen/types';
-import { client } from './client';
-import { PlayerFragment, TokenBalancesFragment } from './fragments';
-import { Patron } from './types';
+  TokenBalancesFragment as TokenBalancesFragmentType,
+} from 'graphql/autogen/types';
+import { client } from 'graphql/client';
+import { PlayerFragment, TokenBalancesFragment } from 'graphql/fragments';
+import { Patron } from 'graphql/types';
 
 // eslint-disable-next-line @typescript-eslint/no-unused-expressions
 /* GraphQL */ `
@@ -65,7 +65,7 @@ const getPlayersFromAddresses = async (
 
 const getpSeedHolders = async (
   limit: number,
-): Promise<Array<TokenBalancesFragmentFragment>> => {
+): Promise<Array<TokenBalancesFragmentType>> => {
   const { data, error } = await client
     .query<GetpSeedHoldersQuery, GetpSeedHoldersQueryVariables>(
       pSeedHoldersQuery,
@@ -84,7 +84,7 @@ const getpSeedHolders = async (
 };
 
 export const getPatrons = async (limit = 50): Promise<Array<Patron>> => {
-  const tokenBalances: Array<TokenBalancesFragmentFragment> = await getpSeedHolders(
+  const tokenBalances: Array<TokenBalancesFragmentType> = await getpSeedHolders(
     limit,
   );
 

--- a/packages/web/graphql/getPlayers.ts
+++ b/packages/web/graphql/getPlayers.ts
@@ -1,5 +1,3 @@
-import { Client } from 'urql';
-
 import {
   GetPlayerFiltersDocument,
   GetPlayerFiltersQuery,
@@ -11,11 +9,12 @@ import {
   GetPlayerUsernamesQueryVariables,
   Maybe,
   Order_By,
+  Player,
   Player_Bool_Exp,
-  PlayerFragmentFragment,
-} from './autogen/types';
-import { client as defaultClient } from './client';
-import { PlayerFragment, PlayerSkillFragment } from './fragments';
+} from 'graphql/autogen/types';
+import { client as defaultClient } from 'graphql/client';
+import { PlayerFragment, PlayerSkillFragment } from 'graphql/fragments';
+import { Client } from 'urql';
 
 // eslint-disable-next-line @typescript-eslint/no-unused-expressions
 /* GraphQL */ `
@@ -110,7 +109,7 @@ export const transformToGraphQLVariables = (
 export type PlayersResponse = {
   error: Error | undefined;
   count: number;
-  players: PlayerFragmentFragment[];
+  players: Player[];
 };
 
 export const getPlayersWithCount = async (
@@ -125,7 +124,7 @@ export const getPlayersWithCount = async (
     .toPromise();
 
   return {
-    players: data?.player ?? [],
+    players: (data?.player as Array<Player>) ?? [],
     count: data?.player_aggregate.aggregate?.count ?? 0,
     error,
   };

--- a/packages/web/graphql/getQuest.ts
+++ b/packages/web/graphql/getQuest.ts
@@ -1,5 +1,3 @@
-import { Client } from 'urql';
-
 import {
   GetQuestDocument,
   GetQuestQuery,
@@ -7,13 +5,14 @@ import {
   GetQuestWithCompletionsDocument,
   GetQuestWithCompletionsQuery,
   GetQuestWithCompletionsQueryVariables,
-} from './autogen/types';
-import { client as defaultClient } from './client';
+} from 'graphql/autogen/types';
+import { client as defaultClient } from 'graphql/client';
 import {
   PlayerFragment,
   QuestFragment,
   QuestWithCompletionFragment,
-} from './fragments';
+} from 'graphql/fragments';
+import { Client } from 'urql';
 
 // eslint-disable-next-line @typescript-eslint/no-unused-expressions
 /* GraphQL */ `

--- a/packages/web/graphql/getQuests.ts
+++ b/packages/web/graphql/getQuests.ts
@@ -1,5 +1,3 @@
-import { Client } from 'urql';
-
 import {
   GetAcceptedQuestsByPlayerDocument,
   GetAcceptedQuestsByPlayerQuery,
@@ -13,9 +11,10 @@ import {
   Order_By,
   QuestStatus_Enum,
   Scalars,
-} from './autogen/types';
-import { client as defaultClient } from './client';
-import { QuestFragment } from './fragments';
+} from 'graphql/autogen/types';
+import { client as defaultClient } from 'graphql/client';
+import { QuestFragment } from 'graphql/fragments';
+import { Client } from 'urql';
 
 // eslint-disable-next-line @typescript-eslint/no-unused-expressions
 /* GraphQL */ `

--- a/packages/web/graphql/queries/enums/getPersonalityInfo.ts
+++ b/packages/web/graphql/queries/enums/getPersonalityInfo.ts
@@ -4,11 +4,10 @@ import BalanceAltImg from 'assets/colors/Balance.svg';
 import ChaosAltImg from 'assets/colors/Chaos.svg';
 import JusticeAltImg from 'assets/colors/Justice.svg';
 import WisdomAltImg from 'assets/colors/Wisdom.svg';
-import gql from 'fake-tag';
 import { client } from 'graphql/client';
 import { PersonalityOption } from 'graphql/types';
 
-const AspectsQuery = gql`
+const AspectsQuery = /* GraphQL */ `
   query GetAspects {
     ColorAspect {
       mask

--- a/packages/web/graphql/queries/enums/getSkills.ts
+++ b/packages/web/graphql/queries/enums/getSkills.ts
@@ -1,6 +1,6 @@
 import {
   GetSkillsQuery,
-  PlayerSkillFragmentFragment,
+  PlayerSkillFragment as PlayerSkillFragmentType,
 } from 'graphql/autogen/types';
 import { client } from 'graphql/client';
 import { PlayerSkillFragment } from 'graphql/fragments';
@@ -16,7 +16,7 @@ const skillsQuery = /* GraphQL */ `
   ${PlayerSkillFragment}
 `;
 
-export const getSkills = async (): Promise<PlayerSkillFragmentFragment[]> => {
+export const getSkills = async (): Promise<PlayerSkillFragmentType[]> => {
   const { data, error } = await client
     .query<GetSkillsQuery>(skillsQuery)
     .toPromise();

--- a/packages/web/graphql/queries/guild.ts
+++ b/packages/web/graphql/queries/guild.ts
@@ -9,7 +9,7 @@ import {
   GetGuildQueryVariables,
   GetGuildsQuery,
   GetGuildsQueryVariables,
-  GuildFragmentFragment,
+  GuildFragment as GuildFragmentType,
   GuildStatus_Enum,
 } from 'graphql/autogen/types';
 import { client } from 'graphql/client';
@@ -27,7 +27,7 @@ const guildQuery = /* GraphQL */ `
 
 export const getGuild = async (
   guildname: string | undefined,
-): Promise<GuildFragmentFragment | undefined> => {
+): Promise<GuildFragmentType | undefined> => {
   if (guildname) {
     const { data } = await client
       .query<GetGuildQuery, GetGuildQueryVariables>(guildQuery, { guildname })
@@ -72,9 +72,7 @@ const guildsQuery = /* GraphQL */ `
   ${GuildFragment}
 `;
 
-export const getGuilds = async (
-  limit = 50,
-): Promise<GuildFragmentFragment[]> => {
+export const getGuilds = async (limit = 50): Promise<GuildFragmentType[]> => {
   const { data, error } = await client
     .query<GetGuildsQuery, GetGuildsQueryVariables>(guildsQuery, { limit })
     .toPromise();

--- a/packages/web/graphql/types.ts
+++ b/packages/web/graphql/types.ts
@@ -37,14 +37,14 @@ export type MeType =
   | null
   | undefined;
 
-export const SkillColors: Record<SkillCategory_Enum, string> = {
+export const SkillColors = {
   [SkillCategory_Enum.Community]: MetaTheme.colors.green['700'],
   [SkillCategory_Enum.Design]: MetaTheme.colors.pink['700'],
   [SkillCategory_Enum.Dev]: MetaTheme.colors.cyan['700'],
   [SkillCategory_Enum.Engineering]: MetaTheme.colors.blue['700'],
   [SkillCategory_Enum.Technologies]: MetaTheme.colors.gray['600'],
   [SkillCategory_Enum.Strategy]: MetaTheme.colors.yellow['700'],
-};
+} as const;
 
 export type GuildPlayer = {
   ethereumAddress: string;

--- a/packages/web/lib/hooks/brightId.ts
+++ b/packages/web/lib/hooks/brightId.ts
@@ -1,5 +1,5 @@
 import { CONFIG } from 'config';
-import { PlayerFragmentFragment } from 'graphql/autogen/types';
+import { Player } from 'graphql/autogen/types';
 import { useEffect, useMemo } from 'react';
 
 const BRIGHTID_CONTEXT = 'MetaGame';
@@ -27,7 +27,7 @@ const isStatusVerified = (
 export const useBrightIdStatus = ({
   player,
 }: {
-  player: PlayerFragmentFragment;
+  player: Player;
 }): {
   verified: boolean;
   deeplink: string;
@@ -59,7 +59,7 @@ export const useBrightIdUpdated = ({
   player,
   poll,
 }: {
-  player: PlayerFragmentFragment;
+  player: Player;
   poll: boolean;
 }): void => {
   const contextId = player.id;

--- a/packages/web/lib/hooks/index.ts
+++ b/packages/web/lib/hooks/index.ts
@@ -1,68 +1,15 @@
-import { Web3Context, Web3ContextType } from 'contexts/Web3Context';
-import { Player, useGetMeQuery } from 'graphql/autogen/types';
-import { Maybe } from 'graphql/jsutils/Maybe';
-import { MeType } from 'graphql/types';
-import { useRouter } from 'next/router';
-import { useContext, useEffect, useMemo, useRef } from 'react';
-import { CombinedError, RequestPolicy } from 'urql';
+import { useEffect, useState } from 'react';
 
-export const useWeb3 = (): Web3ContextType => useContext(Web3Context);
-
-type UseUserOpts = {
-  redirectTo?: string;
-  redirectIfNotFound?: boolean;
-  requestPolicy?: RequestPolicy | undefined;
-};
-
-export const useUser = ({
-  redirectTo,
-  redirectIfNotFound = false,
-  requestPolicy = 'cache-first',
-}: UseUserOpts = {}): {
-  user: Maybe<MeType>;
-  fetching: boolean;
-  error?: CombinedError;
-} => {
-  const { authToken, connecting } = useWeb3();
-  const router = useRouter();
-
-  const [{ data, error, fetching }] = useGetMeQuery({
-    pause: connecting || !authToken,
-    requestPolicy,
-  });
-  const [me] = data?.me ?? [];
-  const user = useMemo(
-    () =>
-      !error && authToken && me ? { ...me, player: me.player as Player } : null,
-    [error, authToken, me],
-  );
-
-  if (error) {
-    // eslint-disable-next-line no-console
-    console.error(`useUser Error: ${error.message}`);
-  }
-
-  useEffect(() => {
-    if (!redirectTo || fetching || connecting) return;
-
-    // If redirectTo is set and redirectIfNotFound is set then
-    // redirect if the user was not found.
-    if (redirectTo && redirectIfNotFound && !user) {
-      router.push(redirectTo);
-    }
-  }, [router, user, fetching, connecting, redirectIfNotFound, redirectTo]);
-
-  return { user, fetching, error };
-};
+export * from './useUser';
 
 // https://www.joshwcomeau.com/react/the-perils-of-rehydration/
 export const useMounted = (): boolean => {
-  const mounted = useRef(false);
+  const [mounted, setMounted] = useState(false);
   useEffect(() => {
-    mounted.current = true;
+    setMounted(true);
     return () => {
-      mounted.current = false;
+      setMounted(false);
     };
   }, []);
-  return mounted.current;
+  return mounted;
 };

--- a/packages/web/lib/hooks/index.ts
+++ b/packages/web/lib/hooks/index.ts
@@ -1,6 +1,7 @@
 import { useEffect, useState } from 'react';
 
 export * from './useUser';
+export * from './useWeb3';
 
 // https://www.joshwcomeau.com/react/the-perils-of-rehydration/
 export const useMounted = (): boolean => {

--- a/packages/web/lib/hooks/opensea.ts
+++ b/packages/web/lib/hooks/opensea.ts
@@ -1,6 +1,6 @@
 import { CONFIG } from 'config';
 import { utils } from 'ethers';
-import { PlayerFragmentFragment } from 'graphql/autogen/types';
+import { Player } from 'graphql/autogen/types';
 import { OpenSeaAPI } from 'opensea-js';
 import {
   AssetEvent,
@@ -12,7 +12,7 @@ import { useEffect, useState } from 'react';
 const opensea = new OpenSeaAPI({ apiKey: CONFIG.openseaApiKey });
 
 type OpenSeaCollectiblesOpts = {
-  player: PlayerFragmentFragment;
+  player: Player;
 };
 
 export type Collectible = {

--- a/packages/web/lib/hooks/quests.ts
+++ b/packages/web/lib/hooks/quests.ts
@@ -1,6 +1,6 @@
 import {
   GetQuestsQueryVariables,
-  QuestFragmentFragment,
+  QuestFragment,
   useGetQuestGuildsQuery,
   useGetQuestsQuery,
 } from 'graphql/autogen/types';
@@ -12,7 +12,7 @@ import { defaultQueryVariables } from '../../graphql/getQuests';
 export type QueryVariableSetter = (key: string, value: any) => void;
 
 interface QuestFilter {
-  quests: QuestFragmentFragment[] | null;
+  quests: QuestFragment[] | null;
   fetching: boolean;
   queryVariables: GetQuestsQueryVariables;
   setQueryVariable: QueryVariableSetter;

--- a/packages/web/lib/hooks/useUser.ts
+++ b/packages/web/lib/hooks/useUser.ts
@@ -1,0 +1,52 @@
+import { Maybe } from '@metafam/utils';
+import { Player, useGetMeQuery } from 'graphql/autogen/types';
+import { useWeb3 } from 'lib/hooks/useWeb3';
+import { useRouter } from 'next/router';
+import { useEffect, useMemo } from 'react';
+import { CombinedError, RequestPolicy } from 'urql';
+
+type UseUserOpts = {
+  redirectTo?: string;
+  redirectIfNotFound?: boolean;
+  requestPolicy?: RequestPolicy | undefined;
+};
+
+export const useUser = ({
+  redirectTo,
+  redirectIfNotFound = false,
+  requestPolicy = 'cache-first',
+}: UseUserOpts = {}): {
+  user: Maybe<Player>;
+  fetching: boolean;
+  error?: CombinedError;
+} => {
+  const { authToken, connecting } = useWeb3();
+  const router = useRouter();
+
+  const [{ data, error, fetching }] = useGetMeQuery({
+    pause: connecting || !authToken,
+    requestPolicy,
+  });
+  const [me] = data?.me ?? [];
+  const user = useMemo(
+    () => (!error && authToken && me ? (me.record as Player) : null),
+    [error, authToken, me],
+  );
+
+  if (error) {
+    // eslint-disable-next-line no-console
+    console.error(`useUser Error: ${error.message}`);
+  }
+
+  useEffect(() => {
+    if (!redirectTo || fetching || connecting) return;
+
+    // If redirectTo is set and redirectIfNotFound is set then
+    // redirect if the user was not found.
+    if (redirectTo && redirectIfNotFound && !user) {
+      router.push(redirectTo);
+    }
+  }, [router, user, fetching, connecting, redirectIfNotFound, redirectTo]);
+
+  return { user, fetching, error };
+};

--- a/packages/web/lib/hooks/useWeb3.ts
+++ b/packages/web/lib/hooks/useWeb3.ts
@@ -1,0 +1,4 @@
+import { Web3Context, Web3ContextType } from 'contexts/Web3Context';
+import { useContext } from 'react';
+
+export const useWeb3 = (): Web3ContextType => useContext(Web3Context);

--- a/packages/web/pages/guild/[guildname].tsx
+++ b/packages/web/pages/guild/[guildname].tsx
@@ -5,7 +5,7 @@ import { GuildLinks } from 'components/Guild/GuildLinks';
 import { GuildPlayers } from 'components/Guild/Section/GuildPlayers';
 import { ProfileSection } from 'components/Profile/ProfileSection';
 import { HeadComponent } from 'components/Seo';
-import { QuestFragmentFragment, QuestStatus_Enum } from 'graphql/autogen/types';
+import { QuestFragment, QuestStatus_Enum } from 'graphql/autogen/types';
 import { getQuests } from 'graphql/getQuests';
 import { getGuild, getGuildnames } from 'graphql/queries/guild';
 import {
@@ -174,7 +174,7 @@ export const getStaticProps = async (
   const guildname = context.params?.guildname;
   const guild = await getGuild(guildname);
 
-  let quests: QuestFragmentFragment[] = [];
+  let quests: QuestFragment[] = [];
   if (guild != null) {
     quests = await getQuests({
       guildId: guild.id,

--- a/packages/web/pages/join/guild/[guildname].tsx
+++ b/packages/web/pages/join/guild/[guildname].tsx
@@ -2,7 +2,7 @@ import { Flex, MetaHeading, useToast } from '@metafam/ds';
 import { FlexContainer, PageContainer } from 'components/Container';
 import { EditGuildFormInputs, GuildForm } from 'components/Guild/GuildForm';
 import {
-  GuildFragmentFragment,
+  GuildFragment,
   GuildInfo,
   GuildType_ActionEnum,
   useUpdateGuildMutation,
@@ -15,7 +15,7 @@ import useSWR from 'swr';
 const SetupGuild: React.FC = () => {
   const router = useRouter();
 
-  const [guild, setGuild] = useState<GuildFragmentFragment | undefined>();
+  const [guild, setGuild] = useState<GuildFragment | undefined>();
   const [updateGuildState, updateGuild] = useUpdateGuildMutation();
   const toast = useToast();
 

--- a/packages/web/pages/me.tsx
+++ b/packages/web/pages/me.tsx
@@ -27,8 +27,8 @@ const CurrentUserPage = (): Maybe<React.ReactElement> => {
     );
   }
 
-  if (user?.player) {
-    return PlayerPage({ player: user.player });
+  if (user) {
+    return PlayerPage({ player: user });
   }
 
   if (error) {

--- a/packages/web/pages/player/[username].tsx
+++ b/packages/web/pages/player/[username].tsx
@@ -157,8 +157,8 @@ export const Grid: React.FC<Props> = ({
   const [exitAlertReset, setExitAlertReset] = useState<boolean>(false);
 
   useEffect(() => {
-    if (!fetching && user?.player && user?.id === player?.id) {
-      setPlayer(user?.player);
+    if (!fetching && user && user.id === player?.id) {
+      setPlayer(user);
       if (connected) {
         setIsOwnProfile(true);
       }
@@ -473,10 +473,10 @@ export const Grid: React.FC<Props> = ({
 type QueryParams = { username: string };
 
 export const getStaticPaths: GetStaticPaths<QueryParams> = async () => {
-  const playerUsernames = await getTopPlayerUsernames();
+  const usernames = await getTopPlayerUsernames();
 
   return {
-    paths: playerUsernames.map((username) => ({
+    paths: usernames.map((username) => ({
       params: { username },
     })),
     fallback: 'blocking',

--- a/packages/web/pages/profile/setup/availability.tsx
+++ b/packages/web/pages/profile/setup/availability.tsx
@@ -16,14 +16,13 @@ export type DefaultSetupProps = InferGetStaticPropsType<typeof getStaticProps>;
 
 const AvailabilitySetup: React.FC<DefaultSetupProps> = () => {
   const { user } = useUser();
-  const { player } = user ?? {};
   const [available, setAvailability] = useState<Maybe<number>>(
-    player?.profile?.availableHours ?? null,
+    user?.profile?.availableHours ?? null,
   );
 
-  if (player) {
-    if (player?.profile?.availableHours != null && available === null) {
-      setAvailability(player.profile.availableHours);
+  if (user) {
+    if (user.profile?.availableHours != null && available === null) {
+      setAvailability(user.profile.availableHours);
     }
   }
 

--- a/packages/web/pages/profile/setup/pronouns.tsx
+++ b/packages/web/pages/profile/setup/pronouns.tsx
@@ -16,10 +16,9 @@ export type DefaultSetupProps = InferGetStaticPropsType<typeof getStaticProps>;
 const PronounsSetup: React.FC<DefaultSetupProps> = () => {
   const [pronouns, setPronouns] = useState<string>();
   const { user } = useUser();
-  const { player } = user ?? {};
 
-  if (player?.profile?.pronouns && pronouns === undefined) {
-    setPronouns(player.profile.pronouns);
+  if (user?.profile?.pronouns && pronouns === undefined) {
+    setPronouns(user.profile.pronouns);
   }
 
   return (

--- a/packages/web/pages/profile/setup/username.tsx
+++ b/packages/web/pages/profile/setup/username.tsx
@@ -17,8 +17,7 @@ const UsernameSetup: React.FC<DefaultSetupProps> = () => {
   const [username, setUsername] = useState<string>();
   const { address } = useWeb3();
   const { user } = useUser();
-  const { player } = user ?? {};
-  const { username: name } = player?.profile ?? {};
+  const { username: name } = user?.profile ?? {};
 
   if (
     name &&

--- a/packages/web/pages/quest/[id]/complete.tsx
+++ b/packages/web/pages/quest/[id]/complete.tsx
@@ -1,23 +1,22 @@
 import { Flex, Heading, LoadingState, Stack, useToast } from '@metafam/ds';
+import { PageContainer } from 'components/Container';
 import { MetaLink } from 'components/Link';
+import { CompletionForm } from 'components/Quest/CompletionForm';
 import {
   CreateQuestCompletionInput,
   useCreateQuestCompletionMutation,
 } from 'graphql/autogen/types';
+import { getSsrClient } from 'graphql/client';
 import { getQuest } from 'graphql/getQuest';
+import { useUser } from 'lib/hooks';
 import {
   GetStaticPaths,
   GetStaticPropsContext,
   InferGetStaticPropsType,
 } from 'next';
 import { useRouter } from 'next/router';
+import Page404 from 'pages/404';
 import React from 'react';
-
-import { PageContainer } from '../../../components/Container';
-import { CompletionForm } from '../../../components/Quest/CompletionForm';
-import { getSsrClient } from '../../../graphql/client';
-import { useUser } from '../../../lib/hooks';
-import Page404 from '../../404';
 
 type Props = InferGetStaticPropsType<typeof getStaticProps>;
 

--- a/packages/web/pages/quest/[id]/edit.tsx
+++ b/packages/web/pages/quest/[id]/edit.tsx
@@ -1,8 +1,10 @@
 import { Heading, LoadingState, useToast } from '@metafam/ds';
+import { PageContainer } from 'components/Container';
+import { CreateQuestFormInputs, QuestForm } from 'components/Quest/QuestForm';
 import {
-  GuildFragmentFragment,
+  GuildFragment,
   PlayerRole,
-  QuestFragmentFragment,
+  QuestFragment,
   useUpdateQuestMutation,
 } from 'graphql/autogen/types';
 import { getSsrClient } from 'graphql/client';
@@ -10,22 +12,16 @@ import { getQuest } from 'graphql/getQuest';
 import { getPlayerRoles } from 'graphql/queries/enums/getRoles';
 import { getSkills } from 'graphql/queries/enums/getSkills';
 import { getGuilds } from 'graphql/queries/guild';
+import { useUser } from 'lib/hooks';
 import { GetStaticPaths, GetStaticPropsContext } from 'next';
 import { useRouter } from 'next/router';
 import React from 'react';
-
-import { PageContainer } from '../../../components/Container';
-import {
-  CreateQuestFormInputs,
-  QuestForm,
-} from '../../../components/Quest/QuestForm';
-import { useUser } from '../../../lib/hooks';
-import { transformCooldownForBackend } from '../../../utils/questHelpers';
-import { CategoryOption, parseSkills } from '../../../utils/skillHelpers';
+import { transformCooldownForBackend } from 'utils/questHelpers';
+import { CategoryOption, parseSkills } from 'utils/skillHelpers';
 
 type Props = {
-  quest: QuestFragmentFragment;
-  guilds: GuildFragmentFragment[];
+  quest: QuestFragment;
+  guilds: GuildFragment[];
   skillChoices: Array<CategoryOption>;
   roleChoices: Array<PlayerRole>;
 };

--- a/packages/web/utils/playerHelpers.ts
+++ b/packages/web/utils/playerHelpers.ts
@@ -5,14 +5,12 @@ import GuildCoverImageSmall from 'assets/guild-background-small.jpeg';
 import PlayerCoverImageFull from 'assets/player-background-full.jpg';
 import PlayerCoverImageSmall from 'assets/player-background-small.jpg';
 import { ethers } from 'ethers';
-import { PlayerFragmentFragment } from 'graphql/autogen/types';
+import { Player } from 'graphql/autogen/types';
 import { GuildPlayer } from 'graphql/types';
 
 import { optimizedImage } from './imageHelpers';
 
-export const getPlayerImage = (
-  player?: PlayerFragmentFragment | GuildPlayer,
-): string => {
+export const getPlayerImage = (player?: Player | GuildPlayer): string => {
   const key = 'profileImageURL';
   const link = optimizedImage(key, player?.profile?.[key]);
 
@@ -24,7 +22,7 @@ export const getPlayerImage = (
     : ProfileIcon;
 };
 
-export const getPlayerBanner = (player: PlayerFragmentFragment): string => {
+export const getPlayerBanner = (player: Player): string => {
   const key = 'bannerImageURL';
   return (
     optimizedImage(key, player.profile?.[key], { height: 100 }) ||
@@ -32,9 +30,7 @@ export const getPlayerBanner = (player: PlayerFragmentFragment): string => {
   );
 };
 
-export const getPlayerBannerFull = (
-  player?: PlayerFragmentFragment,
-): string => {
+export const getPlayerBannerFull = (player?: Player): string => {
   const key = 'bannerImageURL';
   return optimizedImage(key, player?.profile?.[key]) || PlayerCoverImageFull;
 };
@@ -44,20 +40,17 @@ export const getGuildCoverImageFull = (): string => GuildCoverImageFull;
 export const getGuildCoverImageSmall = (): string => GuildCoverImageSmall;
 
 export const getPlayerName = (
-  player?: PlayerFragmentFragment | GuildPlayer,
+  player?: Player | GuildPlayer,
 ): string | undefined =>
   player?.profile?.name ||
   formatIfAddress(player?.profile?.username ?? undefined) ||
   formatAddress(player?.ethereumAddress);
 
-export const getPlayerUsername = (
-  player?: PlayerFragmentFragment,
-): string | undefined =>
+export const getPlayerUsername = (player?: Player): string | undefined =>
   formatIfAddress(player?.profile?.username ?? undefined);
 
-export const getPlayerDescription = (
-  player?: PlayerFragmentFragment,
-): string | undefined => player?.profile?.description ?? undefined;
+export const getPlayerDescription = (player?: Player): string | undefined =>
+  player?.profile?.description ?? undefined;
 
 export const formatAddress = (address = ''): string =>
   `${address.slice(0, 6)}…${address.slice(-4)}`;
@@ -66,7 +59,7 @@ export const formatIfAddress = (username = ''): string =>
   ethers.utils.isAddress(username) ? formatAddress(username) : username;
 
 export const getPlayerURL = (
-  player?: PlayerFragmentFragment | GuildPlayer,
+  player?: Player | GuildPlayer,
   opts: { rel?: boolean; default?: string } = {},
 ): string | undefined => {
   let { username } = player?.profile ?? {};
@@ -79,9 +72,8 @@ export const getPlayerURL = (
   return opts.default;
 };
 
-export const hasImage = (
-  player?: PlayerFragmentFragment | GuildPlayer,
-): boolean => !!player?.profile?.profileImageURL;
+export const hasImage = (player?: Player | GuildPlayer): boolean =>
+  !!player?.profile?.profileImageURL;
 
 export const dispositionFor = (mask?: Maybe<number>) => {
   if (mask == null) return null;

--- a/packages/web/utils/questHelpers.ts
+++ b/packages/web/utils/questHelpers.ts
@@ -3,7 +3,7 @@ import { numbers } from '@metafam/utils';
 import {
   QuestRepetition_Enum,
   QuestStatus_Enum,
-  QuestWithCompletionFragmentFragment,
+  QuestWithCompletionFragment,
 } from '../graphql/autogen/types';
 import { MeType } from '../graphql/types';
 
@@ -35,7 +35,7 @@ export function isAllowedToCreateQuest(balance?: string | null): boolean {
 
 // TODO factorize this with backend
 export function canCompleteQuest(
-  quest?: QuestWithCompletionFragmentFragment | null,
+  quest?: QuestWithCompletionFragment | null,
   user?: MeType | null,
 ): boolean {
   if (!user || !quest) return false;

--- a/packages/web/utils/questHelpers.ts
+++ b/packages/web/utils/questHelpers.ts
@@ -1,11 +1,10 @@
-import { numbers } from '@metafam/utils';
-
+import { Maybe, numbers } from '@metafam/utils';
 import {
+  Player,
   QuestRepetition_Enum,
   QuestStatus_Enum,
   QuestWithCompletionFragment,
-} from '../graphql/autogen/types';
-import { MeType } from '../graphql/types';
+} from 'graphql/autogen/types';
 
 const { BN, amountToDecimal } = numbers;
 
@@ -35,8 +34,8 @@ export function isAllowedToCreateQuest(balance?: string | null): boolean {
 
 // TODO factorize this with backend
 export function canCompleteQuest(
-  quest?: QuestWithCompletionFragment | null,
-  user?: MeType | null,
+  quest?: Maybe<QuestWithCompletionFragment>,
+  user?: Maybe<Player>,
 ): boolean {
   if (!user || !quest) return false;
 
@@ -67,10 +66,10 @@ export function canCompleteQuest(
   return true;
 }
 
-export const QuestRepetitionHint: Record<QuestRepetition_Enum, string> = {
+export const QuestRepetitionHint = {
   [QuestRepetition_Enum.Recurring]:
     'Recurring quests can be done multiple time per player after a cooldown.',
   [QuestRepetition_Enum.Personal]:
     'Personal quests can be done once per player',
   [QuestRepetition_Enum.Unique]: 'Unique quests can be done only once',
-};
+} as const;

--- a/packages/web/utils/skillHelpers.ts
+++ b/packages/web/utils/skillHelpers.ts
@@ -1,10 +1,10 @@
-import { PlayerSkillFragmentFragment } from 'graphql/autogen/types';
+import { PlayerSkillFragment } from 'graphql/autogen/types';
 
 export type SkillMap = {
   [category: string]: CategoryOption;
 };
 
-export type SkillOption = PlayerSkillFragmentFragment & {
+export type SkillOption = PlayerSkillFragment & {
   value: string;
   label: string;
 };
@@ -15,7 +15,7 @@ export type CategoryOption = {
 };
 
 export const parseSkills = (
-  skills: Array<PlayerSkillFragmentFragment>,
+  skills: Array<PlayerSkillFragment>,
 ): Array<CategoryOption> => {
   const skillsMap: SkillMap = {};
   skills.forEach((skill) => {

--- a/yarn.lock
+++ b/yarn.lock
@@ -6027,6 +6027,16 @@
   resolved "https://registry.yarnpkg.com/@typescript-eslint/types/-/types-5.11.0.tgz#ba345818a2540fdf2755c804dc2158517ab61188"
   integrity sha512-cxgBFGSRCoBEhvSVLkKw39+kMzUKHlJGVwwMbPcTZX3qEhuXhrjwaZXWMxVfxDgyMm+b5Q5b29Llo2yow8Y7xQ==
 
+"@typescript-eslint/types@5.4.0":
+  version "5.4.0"
+  resolved "https://registry.yarnpkg.com/@typescript-eslint/types/-/types-5.4.0.tgz#b1c130f4b381b77bec19696c6e3366f9781ce8f2"
+  integrity sha512-GjXNpmn+n1LvnttarX+sPD6+S7giO+9LxDIGlRl4wK3a7qMWALOHYuVSZpPTfEIklYjaWuMtfKdeByx0AcaThA==
+
+"@typescript-eslint/types@5.5.0":
+  version "5.5.0"
+  resolved "https://registry.yarnpkg.com/@typescript-eslint/types/-/types-5.5.0.tgz#fee61ae510e84ed950a53937a2b443e078107003"
+  integrity sha512-OaYTqkW3GnuHxqsxxJ6KypIKd5Uw7bFiQJZRyNi1jbMJnK3Hc/DR4KwB6KJj6PBRkJJoaNwzMNv9vtTk87JhOg==
+
 "@typescript-eslint/typescript-estree@2.34.0":
   version "2.34.0"
   resolved "https://registry.yarnpkg.com/@typescript-eslint/typescript-estree/-/typescript-estree-2.34.0.tgz#14aeb6353b39ef0732cc7f1b8285294937cf37d5"
@@ -6104,6 +6114,22 @@
   integrity sha512-E8w/vJReMGuloGxJDkpPlGwhxocxOpSVgSvjiLO5IxZPmxZF30weOeJYyPSEACwM+X4NziYS9q+WkN/2DHYQwA==
   dependencies:
     "@typescript-eslint/types" "5.11.0"
+    eslint-visitor-keys "^3.0.0"
+
+"@typescript-eslint/visitor-keys@5.4.0":
+  version "5.4.0"
+  resolved "https://registry.yarnpkg.com/@typescript-eslint/visitor-keys/-/visitor-keys-5.4.0.tgz#09bc28efd3621f292fe88c86eef3bf4893364c8c"
+  integrity sha512-PVbax7MeE7tdLfW5SA0fs8NGVVr+buMPrcj+CWYWPXsZCH8qZ1THufDzbXm1xrZ2b2PA1iENJ0sRq5fuUtvsJg==
+  dependencies:
+    "@typescript-eslint/types" "5.4.0"
+    eslint-visitor-keys "^3.0.0"
+
+"@typescript-eslint/visitor-keys@5.5.0":
+  version "5.5.0"
+  resolved "https://registry.yarnpkg.com/@typescript-eslint/visitor-keys/-/visitor-keys-5.5.0.tgz#4787586897b61f26068a3db5c50b3f5d254f9083"
+  integrity sha512-4GzJ1kRtsWzHhdM40tv0ZKHNSbkDhF0Woi/TDwVJX6UICwJItvP7ZTXbjTkCdrors7ww0sYe0t+cIKDAJwZ7Kw==
+  dependencies:
+    "@typescript-eslint/types" "5.5.0"
     eslint-visitor-keys "^3.0.0"
 
 "@urql/core@>=2.1.0", "@urql/core@^2.0.0":
@@ -12741,9 +12767,9 @@ follow-redirects@^1.10.0, follow-redirects@^1.2.5:
   integrity sha512-0vRwd7RKQBTt+mgu87mtYeofLFZpTas2S9zY+jIeuLJMNvudIgF52nr19q40HOwH5RrhWIPuj9puybzSJiRrVg==
 
 follow-redirects@^1.14.4:
-  version "1.14.7"
-  resolved "https://registry.yarnpkg.com/follow-redirects/-/follow-redirects-1.14.7.tgz#2004c02eb9436eee9a21446a6477debf17e81685"
-  integrity sha512-+hbxoLbFMbRKDwohX8GkTataGqO6Jb7jGwpAlwgy2bIz25XtRm7KEzJM76R1WiNT5SwZkX4Y75SwBolkpmE7iQ==
+  version "1.14.8"
+  resolved "https://registry.yarnpkg.com/follow-redirects/-/follow-redirects-1.14.8.tgz#016996fb9a11a100566398b1c6839337d7bfa8fc"
+  integrity sha512-1x0S9UVJHsQprFcEC/qnNzBLcIxsjAV905f/UkQxbclCsoTWlacCNOpQa/anodLl2uaEKFhfWOvM2Qg77+15zA==
 
 for-each@^0.3.3, for-each@~0.3.3:
   version "0.3.3"

--- a/yarn.lock
+++ b/yarn.lock
@@ -6027,16 +6027,6 @@
   resolved "https://registry.yarnpkg.com/@typescript-eslint/types/-/types-5.11.0.tgz#ba345818a2540fdf2755c804dc2158517ab61188"
   integrity sha512-cxgBFGSRCoBEhvSVLkKw39+kMzUKHlJGVwwMbPcTZX3qEhuXhrjwaZXWMxVfxDgyMm+b5Q5b29Llo2yow8Y7xQ==
 
-"@typescript-eslint/types@5.4.0":
-  version "5.4.0"
-  resolved "https://registry.yarnpkg.com/@typescript-eslint/types/-/types-5.4.0.tgz#b1c130f4b381b77bec19696c6e3366f9781ce8f2"
-  integrity sha512-GjXNpmn+n1LvnttarX+sPD6+S7giO+9LxDIGlRl4wK3a7qMWALOHYuVSZpPTfEIklYjaWuMtfKdeByx0AcaThA==
-
-"@typescript-eslint/types@5.5.0":
-  version "5.5.0"
-  resolved "https://registry.yarnpkg.com/@typescript-eslint/types/-/types-5.5.0.tgz#fee61ae510e84ed950a53937a2b443e078107003"
-  integrity sha512-OaYTqkW3GnuHxqsxxJ6KypIKd5Uw7bFiQJZRyNi1jbMJnK3Hc/DR4KwB6KJj6PBRkJJoaNwzMNv9vtTk87JhOg==
-
 "@typescript-eslint/typescript-estree@2.34.0":
   version "2.34.0"
   resolved "https://registry.yarnpkg.com/@typescript-eslint/typescript-estree/-/typescript-estree-2.34.0.tgz#14aeb6353b39ef0732cc7f1b8285294937cf37d5"
@@ -6114,22 +6104,6 @@
   integrity sha512-E8w/vJReMGuloGxJDkpPlGwhxocxOpSVgSvjiLO5IxZPmxZF30weOeJYyPSEACwM+X4NziYS9q+WkN/2DHYQwA==
   dependencies:
     "@typescript-eslint/types" "5.11.0"
-    eslint-visitor-keys "^3.0.0"
-
-"@typescript-eslint/visitor-keys@5.4.0":
-  version "5.4.0"
-  resolved "https://registry.yarnpkg.com/@typescript-eslint/visitor-keys/-/visitor-keys-5.4.0.tgz#09bc28efd3621f292fe88c86eef3bf4893364c8c"
-  integrity sha512-PVbax7MeE7tdLfW5SA0fs8NGVVr+buMPrcj+CWYWPXsZCH8qZ1THufDzbXm1xrZ2b2PA1iENJ0sRq5fuUtvsJg==
-  dependencies:
-    "@typescript-eslint/types" "5.4.0"
-    eslint-visitor-keys "^3.0.0"
-
-"@typescript-eslint/visitor-keys@5.5.0":
-  version "5.5.0"
-  resolved "https://registry.yarnpkg.com/@typescript-eslint/visitor-keys/-/visitor-keys-5.5.0.tgz#4787586897b61f26068a3db5c50b3f5d254f9083"
-  integrity sha512-4GzJ1kRtsWzHhdM40tv0ZKHNSbkDhF0Woi/TDwVJX6UICwJItvP7ZTXbjTkCdrors7ww0sYe0t+cIKDAJwZ7Kw==
-  dependencies:
-    "@typescript-eslint/types" "5.5.0"
     eslint-visitor-keys "^3.0.0"
 
 "@urql/core@>=2.1.0", "@urql/core@^2.0.0":
@@ -12767,9 +12741,9 @@ follow-redirects@^1.10.0, follow-redirects@^1.2.5:
   integrity sha512-0vRwd7RKQBTt+mgu87mtYeofLFZpTas2S9zY+jIeuLJMNvudIgF52nr19q40HOwH5RrhWIPuj9puybzSJiRrVg==
 
 follow-redirects@^1.14.4:
-  version "1.14.8"
-  resolved "https://registry.yarnpkg.com/follow-redirects/-/follow-redirects-1.14.8.tgz#016996fb9a11a100566398b1c6839337d7bfa8fc"
-  integrity sha512-1x0S9UVJHsQprFcEC/qnNzBLcIxsjAV905f/UkQxbclCsoTWlacCNOpQa/anodLl2uaEKFhfWOvM2Qg77+15zA==
+  version "1.14.7"
+  resolved "https://registry.yarnpkg.com/follow-redirects/-/follow-redirects-1.14.7.tgz#2004c02eb9436eee9a21446a6477debf17e81685"
+  integrity sha512-+hbxoLbFMbRKDwohX8GkTataGqO6Jb7jGwpAlwgy2bIz25XtRm7KEzJM76R1WiNT5SwZkX4Y75SwBolkpmE7iQ==
 
 for-each@^0.3.3, for-each@~0.3.3:
   version "0.3.3"

--- a/yarn.lock
+++ b/yarn.lock
@@ -1459,22 +1459,7 @@
     near-api-js "^0.42.0"
     uint8arrays "^2.0.5"
 
-"@ceramicnetwork/common@1.8.0", "@ceramicnetwork/common@^1.3.0", "@ceramicnetwork/common@^1.8.0":
-  version "1.8.0"
-  resolved "https://registry.yarnpkg.com/@ceramicnetwork/common/-/common-1.8.0.tgz#3407f7ee3fb580af8d0f802a517d7c76bb950316"
-  integrity sha512-i16bDukmQ3bHkaJH/B5ANrlomRJNKSCUgoljV3H6v1FH4cKtEo+gmJd79OPwM1jmIbQZ4H67r+Q/XHbIKJrkCQ==
-  dependencies:
-    "@ceramicnetwork/streamid" "^1.3.4"
-    "@overnightjs/logger" "^1.2.0"
-    cids "~1.1.6"
-    cross-fetch "^3.1.4"
-    flat "^5.0.2"
-    lodash.clonedeep "^4.5.0"
-    logfmt "^1.3.2"
-    rxjs "^7.0.0"
-    uint8arrays "^2.0.5"
-
-"@ceramicnetwork/common@^1.11.0":
+"@ceramicnetwork/common@1.11.0", "@ceramicnetwork/common@^1.11.0", "@ceramicnetwork/common@^1.3.0", "@ceramicnetwork/common@^1.8.0":
   version "1.11.0"
   resolved "https://registry.yarnpkg.com/@ceramicnetwork/common/-/common-1.11.0.tgz#f195ef61de73366a64d775496c9328660e9a30a2"
   integrity sha512-UU7/POxSl+Wf5f/Wi/ISxhPqaHKqJ4crvVL9/I4FrnDPEqsUPasBwuo5alN6T2zz+AMDksc+bk1FXKLKKY9VRg==
@@ -1491,18 +1476,6 @@
     logfmt "^1.3.2"
     rxjs "^7.0.0"
     uint8arrays "^2.0.5"
-
-"@ceramicnetwork/http-client@1.5.0":
-  version "1.5.0"
-  resolved "https://registry.yarnpkg.com/@ceramicnetwork/http-client/-/http-client-1.5.0.tgz#ce0eca3e7a398a416fd963d48d2a6c89da024a8d"
-  integrity sha512-2fbIaGxz+gwBx9ZX9l2V8UdkpTPdnAMTYaHzeEgA99N+eyML1Ec6gNDl8qp3IkA2ELXVR6IcDaLykm6BkLaccw==
-  dependencies:
-    "@ceramicnetwork/common" "^1.8.0"
-    "@ceramicnetwork/stream-caip10-link" "^1.2.2"
-    "@ceramicnetwork/stream-tile" "^1.5.0"
-    "@ceramicnetwork/streamid" "^1.3.4"
-    query-string "7.0.1"
-    rxjs "^7.0.0"
 
 "@ceramicnetwork/http-client@1.5.7":
   version "1.5.7"
@@ -1555,7 +1528,7 @@
     caip "~0.9.2"
     did-resolver "^3.1.3"
 
-"@ceramicnetwork/stream-caip10-link@^1.2.2", "@ceramicnetwork/stream-caip10-link@^1.2.9":
+"@ceramicnetwork/stream-caip10-link@1.2.9", "@ceramicnetwork/stream-caip10-link@^1.2.9":
   version "1.2.9"
   resolved "https://registry.yarnpkg.com/@ceramicnetwork/stream-caip10-link/-/stream-caip10-link-1.2.9.tgz#5c50a185e230184a8e0aa905770ab2d5a7bf15ec"
   integrity sha512-DPkJJZ4iYQBMeAFkqIRRKQxq5lb4+4jYWWF2JKAc/XaNtsYw2GRiMEASFL74iMkgkPHxWZnVZg7YXFeDzfR/jw==
@@ -4912,7 +4885,7 @@
   resolved "https://registry.yarnpkg.com/@opentelemetry/context-base/-/context-base-0.14.0.tgz#c67fc20a4d891447ca1a855d7d70fa79a3533001"
   integrity sha512-sDOAZcYwynHFTbLo6n8kIbLiVF3a3BLkrmehJUyEbT9F+Smbi47kLGS2gG2g0fjBLR/Lr1InPD7kXL7FaTqEkw==
 
-"@overnightjs/logger@1.2.1", "@overnightjs/logger@^1.2.0":
+"@overnightjs/logger@1.2.1":
   version "1.2.1"
   resolved "https://registry.yarnpkg.com/@overnightjs/logger/-/logger-1.2.1.tgz#dde726683f39abf726fde57cff578fca96bc183a"
   integrity sha512-ssLUjjj/DXl6m4oydyA6vgVHyJcis4Ui0hS7+EyOxZVMXbiVZeGOficfJfgELTNqTbHLmTb3TBVyJspNDkqbLw==


### PR DESCRIPTION
## Overview

**What features/fixes does this PR include?**

* switches the type used for player / user objects from `PlayerFragmentFragment` to `Player`
* adds `dedupeOperationSuffix` to `codegen.yml` which causes the `…FragmentFragment` types to just be `…Fragment`
* removes the `player` variable from the return result of `useUser`; the `user` that is returned is now what `user.player` was
* moves `useUser` and `useWeb3` into their own files which are reexported from `index.ts` to deal with a circular dependency issue
* finishes the replacement of `fake-tag`'s `gql` with `/* GraphQL */` begun in #1115

**Please provide the GitHub issue number**

These type changes are to clarify and simplify the next set of changes which are a significant revamp of the profile setup wizard as well as the addition of Jotai for local state management. As such, there is no specific issue created for this.

## Follow up Improvement Ideas

I'd like to see

```yaml
namingConvention:
  transformUnderscore: true
```

added to the `codegen.yml`. It would cause the removal of underscores in the generated types, bringing them more in line with all the other types in the system.

The problem is there are both `PlayerRole` *(holds the values of an enum)* and `player_role` *(joins the `player` and `role` tables)* tables. With `transformUnderscore` turned on, both these tables generate the same type names.

`PlayerRole` would need to be renamed, likely to just `Role`.

## Implementation

This was mostly alot of search & replace. There are lots of changed lines, but it's all naming and very little logic.