### PR TITLE
Display a guild's DAOs on their page and support more than one

### DIFF
--- a/hasura/metadata/actions.graphql
+++ b/hasura/metadata/actions.graphql
@@ -103,7 +103,7 @@ input GuildInfo {
   membershipThroughDiscord : Boolean
   discordAdminRoles : [String]!
   discordMembershipRoles : [String]!
-  daos : [GuildDao]
+  daos : [GuildDao!]
 }
 
 input GuildDao {

--- a/hasura/metadata/actions.graphql
+++ b/hasura/metadata/actions.graphql
@@ -21,7 +21,7 @@ type Mutation {
 
 type Mutation {
   saveGuildInformation (
-    guildInformation: GuildInfo!
+    guildInformation: GuildInfoInput!
   ): SaveGuildResponse
 }
 
@@ -88,25 +88,25 @@ input UpdateQuestCompletionInput {
   status : QuestCompletionStatus_ActionEnum!
 }
 
-input GuildInfo {
+input GuildInfoInput {
   uuid : String!
   guildname : String!
   name : String!
   type : GuildType_ActionEnum!
   description : String
-  discordInviteURL : String
-  joinURL : String
-  logoURL : String
-  websiteURL : String
-  twitterURL : String
-  githubURL : String
+  discordInviteUrl : String
+  joinUrl : String
+  logoUrl : String
+  websiteUrl : String
+  twitterUrl : String
+  githubUrl : String
   membershipThroughDiscord : Boolean
   discordAdminRoles : [String]!
   discordMembershipRoles : [String]!
-  daos : [GuildDao!]
+  daos : [GuildDaoInput!]
 }
 
-input GuildDao {
+input GuildDaoInput {
   contractAddress : String!
   network : String!
   label : String

--- a/hasura/metadata/actions.graphql
+++ b/hasura/metadata/actions.graphql
@@ -100,10 +100,17 @@ input GuildInfo {
   websiteURL : String
   twitterURL : String
   githubURL : String
-  daoAddress : String
   membershipThroughDiscord : Boolean
   discordAdminRoles : [String]!
   discordMembershipRoles : [String]!
+  daos : [GuildDao]
+}
+
+input GuildDao {
+  contractAddress : String!
+  network : String!
+  label : String
+  url : String
 }
 
 type UpdateIDXProfileResponse {

--- a/hasura/metadata/actions.yaml
+++ b/hasura/metadata/actions.yaml
@@ -89,8 +89,8 @@ custom_types:
   - name: CreateQuestInput
   - name: CreateQuestCompletionInput
   - name: UpdateQuestCompletionInput
-  - name: GuildInfo
-  - name: GuildDao
+  - name: GuildInfoInput
+  - name: GuildDaoInput
   objects:
   - name: UpdateIDXProfileResponse
   - name: CreateQuestOutput

--- a/hasura/metadata/actions.yaml
+++ b/hasura/metadata/actions.yaml
@@ -34,7 +34,7 @@ actions:
     handler: '{{ACTION_BASE_ENDPOINT}}/idxCache/checkExpired'
 - name: updateIDXProfile
   definition:
-    kind: asynchronous
+    kind: synchronous
     handler: '{{ACTION_BASE_ENDPOINT}}/idxCache/updateSingle'
     forward_client_headers: true
   permissions:

--- a/hasura/metadata/actions.yaml
+++ b/hasura/metadata/actions.yaml
@@ -90,6 +90,7 @@ custom_types:
   - name: CreateQuestCompletionInput
   - name: UpdateQuestCompletionInput
   - name: GuildInfo
+  - name: GuildDao
   objects:
   - name: UpdateIDXProfileResponse
   - name: CreateQuestOutput

--- a/hasura/metadata/tables.yaml
+++ b/hasura/metadata/tables.yaml
@@ -230,6 +230,16 @@
 - table:
     schema: public
     name: guild
+  configuration:
+    custom_root_fields: {}
+    custom_column_names:
+      website_url: websiteUrl
+      join_button_url: joinButtonUrl
+      discord_id: discordId
+      twitter_url: twitterUrl
+      membership_through_discord: membershipThroughDiscord
+      discord_invite_url: discordInviteUrl
+      github_url: githubUrl
   object_relationships:
   - name: GuildType
     using:
@@ -320,6 +330,13 @@
 - table:
     schema: public
     name: guild_metadata
+  configuration:
+    custom_root_fields: {}
+    custom_column_names:
+      discord_metadata: discordMetadata
+      discord_id: discordId
+      creator_id: creatorId
+      guild_id: guildId
   object_relationships:
   - name: guild
     using:
@@ -351,6 +368,11 @@
 - table:
     schema: public
     name: guild_player
+  configuration:
+    custom_root_fields: {}
+    custom_column_names:
+      player_id: playerId
+      guild_id: guildId
   object_relationships:
   - name: Guild
     using:

--- a/hasura/metadata/tables.yaml
+++ b/hasura/metadata/tables.yaml
@@ -157,6 +157,22 @@
   is_enum: true
 - table:
     schema: public
+    name: dao
+  configuration:
+    custom_root_fields: {}
+    custom_column_names:
+      contract_address: contractAddress
+      guild_id: guildId
+- table:
+    schema: public
+    name: dao_player
+  configuration:
+    custom_root_fields: {}
+    custom_column_names:
+      player_id: playerId
+      dao_id: daoId
+- table:
+    schema: public
     name: guild
   object_relationships:
   - name: GuildType

--- a/hasura/metadata/tables.yaml
+++ b/hasura/metadata/tables.yaml
@@ -163,6 +163,53 @@
     custom_column_names:
       contract_address: contractAddress
       guild_id: guildId
+  object_relationships:
+  - name: guild
+    using:
+      foreign_key_constraint_on: guild_id
+  array_relationships:
+  - name: players
+    using:
+      foreign_key_constraint_on:
+        column: dao_id
+        table:
+          schema: public
+          name: dao_player
+  select_permissions:
+  - role: player
+    permission:
+      columns:
+      - contract_address
+      - label
+      - network
+      - url
+      - guild_id
+      - id
+      filter: {}
+  - role: public
+    permission:
+      columns:
+      - contract_address
+      - label
+      - network
+      - url
+      - guild_id
+      - id
+      filter: {}
+  update_permissions:
+  - role: player
+    permission:
+      columns:
+      - contract_address
+      - label
+      - network
+      - url
+      filter:
+        guild:
+          metadata:
+            creator_id:
+              _eq: X-Hasura-User-Id
+      check: null
 - table:
     schema: public
     name: dao_player
@@ -171,6 +218,15 @@
     custom_column_names:
       player_id: playerId
       dao_id: daoId
+  update_permissions:
+  - role: player
+    permission:
+      columns:
+      - visible
+      filter:
+        player_id:
+          _eq: X-Hasura-User-Id
+      check: null
 - table:
     schema: public
     name: guild
@@ -187,6 +243,13 @@
         column_mapping:
           id: guild_id
   array_relationships:
+  - name: daos
+    using:
+      foreign_key_constraint_on:
+        column: guild_id
+        table:
+          schema: public
+          name: dao
   - name: guild_players
     using:
       foreign_key_constraint_on:
@@ -214,27 +277,6 @@
       - join_button_url
       - logo
       - membership_through_discord
-      - moloch_address
-      - name
-      - position
-      - status
-      - twitter_url
-      - type
-      - website_url
-      filter: {}
-  - role: public
-    permission:
-      columns:
-      - description
-      - discord_id
-      - discord_invite_url
-      - github_url
-      - guildname
-      - id
-      - join_button_url
-      - logo
-      - membership_through_discord
-      - moloch_address
       - name
       - position
       - status

--- a/hasura/metadata/tables.yaml
+++ b/hasura/metadata/tables.yaml
@@ -284,6 +284,25 @@
       - type
       - website_url
       filter: {}
+  - role: public
+    permission:
+      columns:
+      - id
+      - type
+      - name
+      - logo
+      - description
+      - join_button_url
+      - website_url
+      - guildname
+      - discord_id
+      - status
+      - discord_invite_url
+      - twitter_url
+      - github_url
+      - position
+      - membership_through_discord
+      filter: {}
   event_triggers:
   - name: syncDiscordGuildMembers
     definition:
@@ -420,6 +439,13 @@
         table:
           schema: public
           name: player_account
+  - name: daos
+    using:
+      foreign_key_constraint_on:
+        column: player_id
+        table:
+          schema: public
+          name: dao_player
   - name: guilds
     using:
       foreign_key_constraint_on:

--- a/hasura/migrations/1645298472918_create_table_public_dao/down.sql
+++ b/hasura/migrations/1645298472918_create_table_public_dao/down.sql
@@ -1,0 +1,1 @@
+DROP TABLE "public"."dao";

--- a/hasura/migrations/1645298472918_create_table_public_dao/up.sql
+++ b/hasura/migrations/1645298472918_create_table_public_dao/up.sql
@@ -1,5 +1,5 @@
 CREATE TABLE "public"."dao" (
-  "id" uuid NOT NULL,
+  "id" uuid NOT NULL DEFAULT gen_random_uuid(),
   "contract_address" text NOT NULL, 
   "network" text NOT NULL DEFAULT 'mainnet', 
   "label" text NULL, 
@@ -7,5 +7,6 @@ CREATE TABLE "public"."dao" (
   "guild_id" uuid NULL, 
   PRIMARY KEY ("id"), 
   FOREIGN KEY ("guild_id") REFERENCES "public"."guild"("id") ON UPDATE no action ON DELETE cascade, 
-  UNIQUE ("id", "contract_address")
+  UNIQUE ("id"),
+  UNIQUE ("contract_address")
 );

--- a/hasura/migrations/1645298472918_create_table_public_dao/up.sql
+++ b/hasura/migrations/1645298472918_create_table_public_dao/up.sql
@@ -1,0 +1,11 @@
+CREATE TABLE "public"."dao" (
+  "id" uuid NOT NULL,
+  "contract_address" text NOT NULL, 
+  "network" text NOT NULL DEFAULT 'mainnet', 
+  "label" text NULL, 
+  "url" text NULL, 
+  "guild_id" uuid NULL, 
+  PRIMARY KEY ("id"), 
+  FOREIGN KEY ("guild_id") REFERENCES "public"."guild"("id") ON UPDATE no action ON DELETE cascade, 
+  UNIQUE ("id", "contract_address")
+);

--- a/hasura/migrations/1645298885991_create_table_public_dao_player/down.sql
+++ b/hasura/migrations/1645298885991_create_table_public_dao_player/down.sql
@@ -1,0 +1,1 @@
+DROP TABLE "public"."dao_player";

--- a/hasura/migrations/1645298885991_create_table_public_dao_player/up.sql
+++ b/hasura/migrations/1645298885991_create_table_public_dao_player/up.sql
@@ -1,6 +1,7 @@
 CREATE TABLE "public"."dao_player" (
   "dao_id" uuid NOT NULL, 
   "player_id" uuid NOT NULL, 
+  "visible" boolean NULL,
   PRIMARY KEY ("dao_id","player_id"), 
   FOREIGN KEY ("dao_id") REFERENCES "public"."dao"("id") ON UPDATE restrict ON DELETE cascade, 
   FOREIGN KEY ("player_id") REFERENCES "public"."player"("id") ON UPDATE restrict ON DELETE cascade

--- a/hasura/migrations/1645298885991_create_table_public_dao_player/up.sql
+++ b/hasura/migrations/1645298885991_create_table_public_dao_player/up.sql
@@ -1,0 +1,7 @@
+CREATE TABLE "public"."dao_player" (
+  "dao_id" uuid NOT NULL, 
+  "player_id" uuid NOT NULL, 
+  PRIMARY KEY ("dao_id","player_id"), 
+  FOREIGN KEY ("dao_id") REFERENCES "public"."dao"("id") ON UPDATE restrict ON DELETE cascade, 
+  FOREIGN KEY ("player_id") REFERENCES "public"."player"("id") ON UPDATE restrict ON DELETE cascade
+);

--- a/hasura/migrations/1645304381138_move_guild_dao_addresses/down.sql
+++ b/hasura/migrations/1645304381138_move_guild_dao_addresses/down.sql
@@ -1,0 +1,1 @@
+DELETE FROM dao WHERE guild_id IS NOT NULL;

--- a/hasura/migrations/1645304381138_move_guild_dao_addresses/up.sql
+++ b/hasura/migrations/1645304381138_move_guild_dao_addresses/up.sql
@@ -1,0 +1,4 @@
+INSERT INTO dao(contract_address, network, guild_id) 
+SELECT moloch_address, 'mainnet', id FROM guild WHERE moloch_address IS NOT NULL;
+
+UPDATE dao SET network = 'xdai' WHERE contract_address IN ('0x30c9aa17fc30e4c23a65680a35b33e8f3b4198a2', '0x5219ffb88175588510e9752A1ecaA3cd217ca783');

--- a/hasura/migrations/1645305421648_alter_table_public_guild_drop_column_moloch_address/down.sql
+++ b/hasura/migrations/1645305421648_alter_table_public_guild_drop_column_moloch_address/down.sql
@@ -1,0 +1,2 @@
+ALTER TABLE "public"."guild" ADD COLUMN "moloch_address" text;
+ALTER TABLE "public"."guild" ALTER COLUMN "moloch_address" DROP NOT NULL;

--- a/hasura/migrations/1645305421648_alter_table_public_guild_drop_column_moloch_address/up.sql
+++ b/hasura/migrations/1645305421648_alter_table_public_guild_drop_column_moloch_address/up.sql
@@ -1,0 +1,1 @@
+ALTER TABLE "public"."guild" DROP COLUMN "moloch_address" CASCADE;

--- a/hasura/migrations/1645725664368_alter_table_public_dao_add_check_constraint_contract_address_is_valid/down.sql
+++ b/hasura/migrations/1645725664368_alter_table_public_dao_add_check_constraint_contract_address_is_valid/down.sql
@@ -1,0 +1,1 @@
+alter table "public"."dao" drop constraint "contract_address_is_valid";

--- a/hasura/migrations/1645725664368_alter_table_public_dao_add_check_constraint_contract_address_is_valid/up.sql
+++ b/hasura/migrations/1645725664368_alter_table_public_dao_add_check_constraint_contract_address_is_valid/up.sql
@@ -1,0 +1,1 @@
+alter table "public"."dao" add constraint "contract_address_is_valid" check (contract_address ~ '^0x([a-z0-9-]{40})$'::text);

--- a/packages/backend/src/handlers/actions/guild/discord/oauthHandler.ts
+++ b/packages/backend/src/handlers/actions/guild/discord/oauthHandler.ts
@@ -47,7 +47,7 @@ export const handleOAuthCallback = async (
       const existingGuild = getGuildMetadataResponse.guild[0];
 
       // if a guild with the same server ID already exists, see if a discord refresh token is set.
-      if (existingGuild.metadata?.discord_metadata?.refreshToken != null) {
+      if (existingGuild.metadata?.discordMetadata?.refreshToken != null) {
         // if so, it's already set up
         // might want to save the new refresh token if it's different...?
         const successResponse: DiscordGuildAuthResponse = {
@@ -60,10 +60,10 @@ export const handleOAuthCallback = async (
         // otherwise, create metadata for the existing guild with the provided info from discord
         await client.CreateGuildMetadata({
           object: {
-            guild_id: existingGuild.id,
-            creator_id: sessionVariables['x-hasura-user-id'],
-            discord_id: discordGuild.id,
-            discord_metadata: parseDiscordMetadata(response.oauthResponse),
+            guildId: existingGuild.id,
+            creatorId: sessionVariables['x-hasura-user-id'],
+            discordId: discordGuild.id,
+            discordMetadata: parseDiscordMetadata(response.oauthResponse),
           },
         });
 
@@ -136,10 +136,10 @@ const createNewGuild = async (
     type: GuildType_Enum.Project,
     name: discordGuild.name,
     guildname: discordGuild.name.toLowerCase().replace(/[^a-z0-9]/g, ''),
-    discord_id: discordGuild.id,
+    discordId: discordGuild.id,
     status: GuildStatus_Enum.Pending,
     position: GuildPosition_Enum.External,
-    membership_through_discord: true,
+    membershipThroughDiscord: true,
   };
 
   if (discordMetadata.logoHash != null) {
@@ -156,10 +156,10 @@ const createNewGuild = async (
     const newGuild = createGuildResponse.insert_guild_one;
 
     const newGuildMetadataPayload: Guild_Metadata_Insert_Input = {
-      creator_id: creatorId,
-      discord_id: discordGuild.id,
-      guild_id: newGuild.id,
-      discord_metadata: discordMetadata,
+      creatorId,
+      discordId: discordGuild.id,
+      guildId: newGuild.id,
+      discordMetadata,
     };
     const createGuildMetadataResponse = await client.CreateGuildMetadata({
       object: newGuildMetadataPayload,

--- a/packages/backend/src/handlers/graphql/mutations.ts
+++ b/packages/backend/src/handlers/graphql/mutations.ts
@@ -156,10 +156,10 @@ export const CreateQuestCompletion = /* GraphQL */ `
 
   mutation CreateGuildMetadata($object: guild_metadata_insert_input!) {
     insert_guild_metadata_one(object: $object) {
-      creator_id
-      discord_id
-      guild_id
-      discord_metadata
+      creatorId
+      discordId
+      guildId
+      discordMetadata
     }
   }
 
@@ -168,10 +168,10 @@ export const CreateQuestCompletion = /* GraphQL */ `
     $discordMetadata: jsonb
   ) {
     update_guild_metadata_by_pk(
-      pk_columns: { guild_id: $guildId }
-      _set: { discord_metadata: $discordMetadata }
+      pk_columns: { guildId: $guildId }
+      _set: { discordMetadata: $discordMetadata }
     ) {
-      guild_id
+      guildId
     }
   }
 
@@ -190,7 +190,7 @@ export const CreateQuestCompletion = /* GraphQL */ `
   }
 
   mutation RemoveAllGuildMembers($guildId: uuid!) {
-    delete_guild_player(where: { guild_id: { _eq: $guildId } }) {
+    delete_guild_player(where: { guildId: { _eq: $guildId } }) {
       affected_rows
     }
   }

--- a/packages/backend/src/handlers/graphql/mutations.ts
+++ b/packages/backend/src/handlers/graphql/mutations.ts
@@ -194,4 +194,10 @@ export const CreateQuestCompletion = /* GraphQL */ `
       affected_rows
     }
   }
+
+  mutation UpdateDao($daoId: uuid!, $object: dao_set_input!) {
+    update_dao_by_pk(pk_columns: { id: $daoId }, _set: $object) {
+      id
+    }
+  }
 `;

--- a/packages/backend/src/handlers/graphql/mutations.ts
+++ b/packages/backend/src/handlers/graphql/mutations.ts
@@ -201,11 +201,14 @@ export const CreateQuestCompletion = /* GraphQL */ `
     }
   }
 
-  mutation DetachDaosFromGuild($contractAddresses: [String!]!) {
-    update_dao(
-      where: { contractAddress: { _in: $contractAddresses } }
-      _set: { guildId: null }
-    ) {
+  mutation DetachDaosFromGuild($ids: [uuid!]!) {
+    update_dao(where: { id: { _in: $ids } }, _set: { guildId: null }) {
+      affected_rows
+    }
+  }
+
+  mutation DeleteDaos($ids: [uuid!]!) {
+    delete_dao(where: { id: { _in: $ids } }) {
       affected_rows
     }
   }

--- a/packages/backend/src/handlers/graphql/mutations.ts
+++ b/packages/backend/src/handlers/graphql/mutations.ts
@@ -200,4 +200,19 @@ export const CreateQuestCompletion = /* GraphQL */ `
       id
     }
   }
+
+  mutation DetachDaosFromGuild($contractAddresses: [String!]!) {
+    update_dao(
+      where: { contractAddress: { _in: $contractAddresses } }
+      _set: { guildId: null }
+    ) {
+      affected_rows
+    }
+  }
+
+  mutation InsertDaos($objects: [dao_insert_input!]!) {
+    insert_dao(objects: $objects) {
+      affected_rows
+    }
+  }
 `;

--- a/packages/backend/src/handlers/graphql/queries.ts
+++ b/packages/backend/src/handlers/graphql/queries.ts
@@ -104,6 +104,10 @@ export const GuildFragment = /* GraphQL */ `
         network
         label
         url
+        players {
+          playerId
+          visible
+        }
       }
     }
   }

--- a/packages/backend/src/handlers/graphql/queries.ts
+++ b/packages/backend/src/handlers/graphql/queries.ts
@@ -82,14 +82,14 @@ export const GuildFragment = /* GraphQL */ `
     id
     guildname
     description
-    join_button_url
+    joinButtonUrl
     logo
     name
     type
-    website_url
-    discord_id
+    websiteUrl
+    discordId
     status
-    membership_through_discord
+    membershipThroughDiscord
   }
 `;
 
@@ -99,6 +99,7 @@ export const GuildFragment = /* GraphQL */ `
       ...GuildFragment,
       daos { 
         id
+        guildId
         contractAddress
         network
         label
@@ -109,14 +110,14 @@ export const GuildFragment = /* GraphQL */ `
   ${GuildFragment}
 
   query GetGuildMetadataByDiscordId($discordId: String!) {
-    guild(where: { discord_id: { _eq: $discordId } }) {
+    guild(where: { discordId: { _eq: $discordId } }) {
       id
-      discord_id
+      discordId
       guildname
       metadata {
-        guild_id
-        creator_id
-        discord_metadata
+        guildId
+        creatorId
+        discordMetadata
       }
     }
   }
@@ -128,11 +129,11 @@ export const GuildFragment = /* GraphQL */ `
   }
 
   query GetGuildMetadataById($id: uuid!) {
-    guild_metadata(where: { guild_id: { _eq: $id } }) {
-      guild_id
-      creator_id
-      discord_id
-      discord_metadata
+    guild_metadata(where: { guildId: { _eq: $id } }) {
+      guildId
+      creatorId
+      discordId
+      discordMetadata
     }
   }
 
@@ -151,7 +152,7 @@ export const GuildFragment = /* GraphQL */ `
   query GetGuildPlayerDiscordIds($guildId: uuid!, $playerId: uuid!) {
     guild_player(
       where: {
-        _and: { guild_id: { _eq: $guildId }, player_id: { _eq: $playerId } }
+        _and: { guildId: { _eq: $guildId }, playerId: { _eq: $playerId } }
       }
     ) {
       Player {
@@ -160,7 +161,7 @@ export const GuildFragment = /* GraphQL */ `
       }
       Guild {
         id
-        discord_id
+        discordId
       }
     }
   }

--- a/packages/backend/src/handlers/graphql/queries.ts
+++ b/packages/backend/src/handlers/graphql/queries.ts
@@ -1,4 +1,5 @@
-// eslint-disable-next-line @typescript-eslint/no-unused-expressions
+/* eslint-disable @typescript-eslint/no-unused-expressions */
+
 /* GraphQL */ `
   query GetPlayer($playerId: uuid!) {
     player_by_pk(id: $playerId) {
@@ -83,7 +84,6 @@ export const GuildFragment = /* GraphQL */ `
     description
     join_button_url
     logo
-    moloch_address
     name
     type
     website_url
@@ -93,11 +93,17 @@ export const GuildFragment = /* GraphQL */ `
   }
 `;
 
-// eslint-disable-next-line @typescript-eslint/no-unused-expressions
 /* GraphQL */ `
   query GetGuild($id: uuid!) {
     guild(where: { id: { _eq: $id } }) {
-      ...GuildFragment
+      ...GuildFragment,
+      daos { 
+        id
+        contractAddress
+        network
+        label
+        url
+      }
     }
   }
   ${GuildFragment}

--- a/packages/backend/src/handlers/remote-schemas/resolvers/discord/resolver.ts
+++ b/packages/backend/src/handlers/remote-schemas/resolvers/discord/resolver.ts
@@ -32,8 +32,7 @@ export const getDiscordServerMemberRoles: QueryResolvers['getDiscordServerMember
     guildId,
     playerId,
   });
-  const guildDiscordId =
-    getGuildPlayerResponse.guild_player[0].Guild.discord_id;
+  const guildDiscordId = getGuildPlayerResponse.guild_player[0].Guild.discordId;
   const playerDiscordId =
     getGuildPlayerResponse.guild_player[0].Player.discordId;
 

--- a/packages/backend/src/handlers/triggers/playerRankUpdated.ts
+++ b/packages/backend/src/handlers/triggers/playerRankUpdated.ts
@@ -55,7 +55,7 @@ export const playerRankUpdated = async (payload: TriggerPayload<Player>) => {
       discordId: Constants.METAFAM_DISCORD_GUILD_ID,
     });
     const rankDiscordRoleIds = getGuildResponse.guild[0].metadata
-      ?.discord_metadata?.rankRoleIds as RankRoleIds;
+      ?.discordMetadata?.rankRoleIds as RankRoleIds;
 
     const discordPlayer = await guild.members.fetch(playerDiscordId);
     if (discordPlayer == null) {

--- a/packages/backend/src/handlers/triggers/playerRoleChanged.ts
+++ b/packages/backend/src/handlers/triggers/playerRoleChanged.ts
@@ -50,7 +50,7 @@ export const playerRoleChanged = async (
       discordId: Constants.METAFAM_DISCORD_GUILD_ID,
     });
     const metadata: GuildDiscordMetadata =
-      getGuildResponse.guild[0]?.metadata?.discord_metadata;
+      getGuildResponse.guild[0]?.metadata?.discordMetadata;
     const roleIds = metadata.playerRoles as RoleIds;
 
     const discordPlayer = await guild.members.fetch(discordId);

--- a/packages/backend/src/handlers/triggers/syncDiscordGuildMembers.ts
+++ b/packages/backend/src/handlers/triggers/syncDiscordGuildMembers.ts
@@ -40,7 +40,7 @@ export const syncAllGuildDiscordMembers = async (
 
     await Promise.all(
       guilds
-        .filter((guild) => guild.membership_through_discord === true)
+        .filter((guild) => guild.membershipThroughDiscord === true)
         .map((guild) => syncGuildMembers(guild)),
     );
 
@@ -55,7 +55,7 @@ export const syncAllGuildDiscordMembers = async (
 };
 
 const syncGuildMembers = async (guild: GuildFragment) => {
-  if (guild?.discord_id == null) return;
+  if (guild?.discordId == null) return;
 
   const getMetadataResponse = await client.GetGuildMetadataById({
     id: guild.id,
@@ -63,13 +63,13 @@ const syncGuildMembers = async (guild: GuildFragment) => {
   const guildMetadata = getMetadataResponse.guild_metadata[0];
   if (
     guildMetadata == null ||
-    guildMetadata.discord_metadata == null ||
-    guild.membership_through_discord === false
+    guildMetadata.discordMetadata == null ||
+    guild.membershipThroughDiscord === false
   )
     return;
 
   // at least one membership role must be defined
-  const discordServerMembershipRoles = (guildMetadata.discord_metadata as GuildDiscordMetadata)
+  const discordServerMembershipRoles = (guildMetadata.discordMetadata as GuildDiscordMetadata)
     .membershipRoleIds;
   if (
     discordServerMembershipRoles == null ||
@@ -91,10 +91,10 @@ const syncGuildMembers = async (guild: GuildFragment) => {
   }
 
   const discordClient = await createDiscordClient();
-  const discordGuild = await discordClient.guilds.fetch(guild.discord_id);
+  const discordGuild = await discordClient.guilds.fetch(guild.discordId);
 
   if (discordGuild == null)
-    throw new Error(`Discord server ${guild.discord_id} does not exist!`);
+    throw new Error(`Discord server ${guild.discordId} does not exist!`);
 
   const getGuildMembersResponse = await client.GetGuildMembers({
     id: guild.id,
@@ -135,8 +135,8 @@ const syncGuildMembers = async (guild: GuildFragment) => {
 
   const playersToAdd: Guild_Player_Insert_Input[] = getPlayerIdsResponse.player.map(
     (player) => ({
-      guild_id: guild.id,
-      player_id: player.id,
+      guildId: guild.id,
+      playerId: player.id,
     }),
   );
 

--- a/packages/design-system/src/icons/ChainIcon.tsx
+++ b/packages/design-system/src/icons/ChainIcon.tsx
@@ -19,10 +19,10 @@ export const ChainIcon: React.FC<Props & IconProps> = ({ chain, ...props }) => {
     if (lower?.includes('polygon')) {
       return { Icon: PolygonIcon, name: 'Polygon' };
     }
-    return { Icon: EthereumIcon, name: 'Ethereum' };
+    return { Icon: EthereumIcon, name: 'Mainnet' };
   })();
   return (
-    <Tooltip label={`on the ${info.name} network`} hasArrow>
+    <Tooltip label={`on ${info.name}`} hasArrow>
       <info.Icon {...props} />
     </Tooltip>
   );

--- a/packages/design-system/src/index.ts
+++ b/packages/design-system/src/index.ts
@@ -86,6 +86,7 @@ export {
   ChakraComponent,
   ChakraProps,
   ChakraProvider,
+  CloseButton,
   Collapse,
   ComponentWithAs,
   Container,

--- a/packages/web/components/Forms/Field.tsx
+++ b/packages/web/components/Forms/Field.tsx
@@ -16,12 +16,12 @@ export const Field: React.FC<FieldProps> = ({ children, error, label }) => (
       </Text>
 
       <Text textStyle="caption" textAlign="left" color="red.400" mr={4}>
-        {error?.type === 'required' && 'Required'}
-        {error?.type === 'pattern' && 'Invalid URL'}
-        {error?.type === 'minLength' && 'Too short'}
-        {error?.type === 'maxLength' && 'Too long'}
-        {error?.type === 'min' && 'Too small'}
-        {error?.type === 'validate' && error.message}
+        {error?.type === 'required' && (error.message || 'Required')}
+        {error?.type === 'pattern' && (error.message || 'Invalid URL')}
+        {error?.type === 'minLength' && (error.message || 'Too short')}
+        {error?.type === 'maxLength' && (error.message || 'Too long')}
+        {error?.type === 'min' && (error.message || 'Too small')}
+        {error?.type === 'validate' && (error.message || 'Invalid')}
       </Text>
     </Flex>
 

--- a/packages/web/components/Guild/GuildForm.tsx
+++ b/packages/web/components/Guild/GuildForm.tsx
@@ -101,7 +101,15 @@ const getDefaultFormValues = (
       ? []
       : roleOptions.filter((r) => discordMembershipRoleIds.includes(r.value));
 
-  const daos = guild.daos?.length > 0 ? guild.daos : [placeholderDaoInput];
+  const daos =
+    guild.daos?.length > 0
+      ? guild.daos.map((d) => ({
+          contractAddress: d.contractAddress,
+          network: d.network,
+          label: d.label,
+          url: d.url,
+        }))
+      : [placeholderDaoInput];
 
   return {
     guildname: guild.guildname,

--- a/packages/web/components/Guild/GuildHero.tsx
+++ b/packages/web/components/Guild/GuildHero.tsx
@@ -1,12 +1,50 @@
-import { Avatar, Box, MetaButton, Text, VStack } from '@metafam/ds';
+import {
+  Avatar,
+  Box,
+  EditIcon,
+  IconButton,
+  Link,
+  MetaButton,
+  Text,
+  VStack,
+} from '@metafam/ds';
 import { ProfileSection } from 'components/Profile/ProfileSection';
 import { GuildFragment } from 'graphql/autogen/types';
 import React from 'react';
 
-type Props = { guild: GuildFragment };
+type Props = {
+  guild: GuildFragment;
+  canEdit: boolean;
+};
 
-export const GuildHero: React.FC<Props> = ({ guild }) => (
+export const GuildHero: React.FC<Props> = ({ guild, canEdit }) => (
   <ProfileSection>
+    {canEdit && (
+      <Box pos="absolute" right={3} top={3}>
+        <Link
+          _hover={{ textDecoration: 'none' }}
+          href={`/join/guild/${guild.guildname}`}
+        >
+          <IconButton
+            _focus={{ boxShadow: 'none' }}
+            variant="outline"
+            borderWidth={2}
+            aria-label="Edit Profile Info"
+            size="lg"
+            borderColor="pinkShadeOne"
+            bg="rgba(17, 17, 17, 0.9)"
+            color="pinkShadeOne"
+            _hover={{ color: 'white', borderColor: 'white' }}
+            icon={<EditIcon />}
+            isRound
+            _active={{
+              transform: 'scale(0.8)',
+              backgroundColor: 'transparent',
+            }}
+          />
+        </Link>
+      </Box>
+    )}
     <VStack spacing={8}>
       {guild.logo ? (
         <Avatar
@@ -28,8 +66,8 @@ export const GuildHero: React.FC<Props> = ({ guild }) => (
       <Box>
         <Text>{guild.description}</Text>
       </Box>
-      {guild.join_button_url ? (
-        <MetaButton as="a" href={guild.join_button_url} target="_blank">
+      {guild.joinButtonUrl ? (
+        <MetaButton as="a" href={guild.joinButtonUrl} target="_blank">
           Join
         </MetaButton>
       ) : null}

--- a/packages/web/components/Guild/GuildLinks.tsx
+++ b/packages/web/components/Guild/GuildLinks.tsx
@@ -1,68 +1,103 @@
-import { IconButton, Wrap, WrapItem } from '@metafam/ds';
+import { IconButton, Text, Wrap, WrapItem } from '@metafam/ds';
+import { ExternalDaoLink } from 'components/Player/PlayerGuild';
+import { PlayerHeroTile } from 'components/Player/Section/PlayerHeroTile';
 import { ProfileSection } from 'components/Profile/ProfileSection';
 import { GuildFragment } from 'graphql/autogen/types';
-import React from 'react';
+import React, { useMemo } from 'react';
 import { FaDiscord, FaGithub, FaGlobe, FaTwitter } from 'react-icons/fa';
+import { getDaoLink } from 'utils/daoHelpers';
 
 type Props = {
   guild: GuildFragment;
 };
 
-export const GuildLinks: React.FC<Props> = ({ guild }) => (
-  <ProfileSection title="Links">
-    <Wrap>
-      {guild.websiteUrl ? (
-        <WrapItem>
-          <a href={guild.websiteUrl} target="_blank" rel="noreferrer">
-            <IconButton
-              variant="outline"
-              aria-label="Discord Server"
-              size="lg"
-              colorScheme="blackAlpha"
-              icon={<FaGlobe />}
-            />
-          </a>
-        </WrapItem>
-      ) : null}
-      {guild.discordInviteUrl ? (
-        <WrapItem>
-          <a href={guild.discordInviteUrl} target="_blank" rel="noreferrer">
-            <IconButton
-              variant="outline"
-              aria-label="Discord Server"
-              size="lg"
-              bgColor="discord"
-              icon={<FaDiscord />}
-            />
-          </a>
-        </WrapItem>
-      ) : null}
-      {guild.githubUrl ? (
-        <WrapItem>
-          <a href={guild.githubUrl} target="_blank" rel="noreferrer">
-            <IconButton
-              variant="outline"
-              aria-label="Github"
-              size="lg"
-              colorScheme="github"
-              icon={<FaGithub />}
-            />
-          </a>
-        </WrapItem>
-      ) : null}
-      {guild.twitterUrl ? (
-        <WrapItem>
-          <a href={guild.twitterUrl} target="_blank" rel="noreferrer">
-            <IconButton
-              variant="outline"
-              aria-label="Twitter"
-              size="lg"
-              colorScheme="twitter"
-              icon={<FaTwitter />}
-            />
-          </a>
-        </WrapItem>
-      ) : null}
-    </Wrap>
-  </ProfileSection>
-);
+export const GuildLinks: React.FC<Props> = ({ guild }) => {
+  const daoHrefs = useMemo(
+    () =>
+      guild.daos.map(
+        (dao) => dao.url || getDaoLink(dao.network, dao.contractAddress),
+      ),
+    [guild],
+  );
+
+  const hasIconLink =
+    guild.websiteUrl ||
+    guild.discordInviteUrl ||
+    guild.githubUrl ||
+    guild.twitterUrl;
+
+  return (
+    <ProfileSection title="Links">
+      {hasIconLink && (
+        <Wrap mb={4}>
+          {guild.websiteUrl ? (
+            <WrapItem>
+              <a href={guild.websiteUrl} target="_blank" rel="noreferrer">
+                <IconButton
+                  variant="outline"
+                  aria-label="Discord Server"
+                  size="lg"
+                  colorScheme="blackAlpha"
+                  icon={<FaGlobe />}
+                />
+              </a>
+            </WrapItem>
+          ) : null}
+          {guild.discordInviteUrl ? (
+            <WrapItem>
+              <a href={guild.discordInviteUrl} target="_blank" rel="noreferrer">
+                <IconButton
+                  variant="outline"
+                  aria-label="Discord Server"
+                  size="lg"
+                  bgColor="discord"
+                  icon={<FaDiscord />}
+                />
+              </a>
+            </WrapItem>
+          ) : null}
+          {guild.githubUrl ? (
+            <WrapItem>
+              <a href={guild.githubUrl} target="_blank" rel="noreferrer">
+                <IconButton
+                  variant="outline"
+                  aria-label="Github"
+                  size="lg"
+                  colorScheme="github"
+                  icon={<FaGithub />}
+                />
+              </a>
+            </WrapItem>
+          ) : null}
+          {guild.twitterUrl ? (
+            <WrapItem>
+              <a href={guild.twitterUrl} target="_blank" rel="noreferrer">
+                <IconButton
+                  variant="outline"
+                  aria-label="Twitter"
+                  size="lg"
+                  colorScheme="twitter"
+                  icon={<FaTwitter />}
+                />
+              </a>
+            </WrapItem>
+          ) : null}
+        </Wrap>
+      )}
+      <Wrap justify="space-between" w="full">
+        {guild.daos?.map((dao, index) => (
+          <WrapItem key={index}>
+            <PlayerHeroTile title={dao.label || 'DAO'}>
+              <ExternalDaoLink
+                daoUrl={daoHrefs[index]}
+                linkProps={{ _hover: { textDecoration: 'underline' } }}
+              >
+                <Text fontSize="sm">{dao.contractAddress}</Text>
+              </ExternalDaoLink>
+            </PlayerHeroTile>
+          </WrapItem>
+        ))}
+      </Wrap>
+    </ProfileSection>
+  );
+};

--- a/packages/web/components/Guild/GuildLinks.tsx
+++ b/packages/web/components/Guild/GuildLinks.tsx
@@ -11,9 +11,9 @@ type Props = {
 export const GuildLinks: React.FC<Props> = ({ guild }) => (
   <ProfileSection title="Links">
     <Wrap>
-      {guild.website_url ? (
+      {guild.websiteUrl ? (
         <WrapItem>
-          <a href={guild.website_url} target="_blank" rel="noreferrer">
+          <a href={guild.websiteUrl} target="_blank" rel="noreferrer">
             <IconButton
               variant="outline"
               aria-label="Discord Server"
@@ -24,9 +24,9 @@ export const GuildLinks: React.FC<Props> = ({ guild }) => (
           </a>
         </WrapItem>
       ) : null}
-      {guild.discord_invite_url ? (
+      {guild.discordInviteUrl ? (
         <WrapItem>
-          <a href={guild.discord_invite_url} target="_blank" rel="noreferrer">
+          <a href={guild.discordInviteUrl} target="_blank" rel="noreferrer">
             <IconButton
               variant="outline"
               aria-label="Discord Server"
@@ -37,9 +37,9 @@ export const GuildLinks: React.FC<Props> = ({ guild }) => (
           </a>
         </WrapItem>
       ) : null}
-      {guild.github_url ? (
+      {guild.githubUrl ? (
         <WrapItem>
-          <a href={guild.github_url} target="_blank" rel="noreferrer">
+          <a href={guild.githubUrl} target="_blank" rel="noreferrer">
             <IconButton
               variant="outline"
               aria-label="Github"
@@ -50,9 +50,9 @@ export const GuildLinks: React.FC<Props> = ({ guild }) => (
           </a>
         </WrapItem>
       ) : null}
-      {guild.twitter_url ? (
+      {guild.twitterUrl ? (
         <WrapItem>
-          <a href={guild.twitter_url} target="_blank" rel="noreferrer">
+          <a href={guild.twitterUrl} target="_blank" rel="noreferrer">
             <IconButton
               variant="outline"
               aria-label="Twitter"

--- a/packages/web/components/Guild/GuildLinks.tsx
+++ b/packages/web/components/Guild/GuildLinks.tsx
@@ -5,7 +5,7 @@ import { ProfileSection } from 'components/Profile/ProfileSection';
 import { GuildFragment } from 'graphql/autogen/types';
 import React, { useMemo } from 'react';
 import { FaDiscord, FaGithub, FaGlobe, FaTwitter } from 'react-icons/fa';
-import { getDaoLink } from 'utils/daoHelpers';
+import { getDAOLink } from 'utils/daoHelpers';
 
 type Props = {
   guild: GuildFragment;
@@ -15,7 +15,7 @@ export const GuildLinks: React.FC<Props> = ({ guild }) => {
   const daoHrefs = useMemo(
     () =>
       guild.daos.map(
-        (dao) => dao.url || getDaoLink(dao.network, dao.contractAddress),
+        (dao) => dao.url || getDAOLink(dao.network, dao.contractAddress),
       ),
     [guild],
   );
@@ -89,8 +89,8 @@ export const GuildLinks: React.FC<Props> = ({ guild }) => {
           <WrapItem key={index}>
             <PlayerHeroTile title={dao.label || 'DAO'}>
               <ExternalDaoLink
-                daoUrl={daoHrefs[index]}
-                linkProps={{ _hover: { textDecoration: 'underline' } }}
+                daoURL={daoHrefs[index]}
+                _hover={{ textDecoration: 'underline' }}
               >
                 <Text fontSize="sm">{dao.contractAddress}</Text>
               </ExternalDaoLink>

--- a/packages/web/components/Guild/GuildTile.tsx
+++ b/packages/web/components/Guild/GuildTile.tsx
@@ -57,8 +57,8 @@ export const GuildTile: React.FC<Props> = ({ guild }) => (
         </LinkOverlay>
       </NextLink>
       <MetaTileBody>
-        {guild.join_button_url ? (
-          <MetaButton as="a" href={guild.join_button_url} target="_blank">
+        {guild.joinButtonUrl ? (
+          <MetaButton as="a" href={guild.joinButtonUrl} target="_blank">
             Join
           </MetaButton>
         ) : null}

--- a/packages/web/components/Player/PlayerGuild.tsx
+++ b/packages/web/components/Player/PlayerGuild.tsx
@@ -15,7 +15,7 @@ export const LinkGuild: React.FC<LinkGuildProps> = ({
     return <InternalGuildLink guildName={guildname} {...{ children }} />;
   }
   if (daoURL != null) {
-    return <DaoHausLink {...{ daoURL, children }} />;
+    return <ExternalDaoLink daoURL={daoURL} children={children} />;
   }
   return <>{children}</>;
 };
@@ -37,7 +37,7 @@ type DaoHausLinkProps = {
   daoURL: string | null;
 };
 
-export const DaoHausLink: React.FC<DaoHausLinkProps & LinkProps> = ({
+export const ExternalDaoLink: React.FC<DaoHausLinkProps & LinkProps> = ({
   daoURL,
   children,
   _hover = {},

--- a/packages/web/components/Setup/SetupMemberships.tsx
+++ b/packages/web/components/Setup/SetupMemberships.tsx
@@ -3,7 +3,6 @@ import {
   ChainIcon,
   Flex,
   Heading,
-  HStack,
   Image,
   MetaButton,
   MetaHeading,
@@ -66,7 +65,7 @@ export const SetupMemberships: React.FC<SetupMembershipsProps> = ({
 
         return (
           <Box maxW="50rem">
-            <Text mb={10} maxW="35rem" textAlign="center">
+            <Text mb={10} textAlign="center">
               We found the following guilds associated with your account and
               automatically added them to your profile.
             </Text>
@@ -107,31 +106,37 @@ const MembershipListing: React.FC<MembershipListingProps> = ({
   return (
     <ExternalDaoLink
       daoURL={daoURL}
-      bg="dark"
+      bg="rgba(0, 0, 0, 0.2)"
       border="2px transparent solid"
       _hover={{ borderColor: 'purpleBoxLight' }}
     >
-      <HStack alignItems="center" mb={4}>
-        <Flex bg="purpleBoxLight" width={16} height={16} mr={6}>
-          {avatarURL ? (
-            <Image
-              src={avatarURL}
-              w="3.25rem"
-              h="3.25rem"
-              m="auto"
-              borderRadius={4}
-            />
-          ) : (
-            <ChainIcon {...{ chain }} boxSize={16} p={2} />
-          )}
+      <Flex align="center" p={2}>
+        <Flex align="center">
+          <Box bg="purpleBoxLight" minW={16} h={16} borderRadius={8}>
+            {avatarURL ? (
+              <Image
+                src={avatarURL}
+                w={14}
+                h={14}
+                mx="auto"
+                my={1}
+                borderRadius={4}
+              />
+            ) : (
+              <ChainIcon {...{ chain }} boxSize={16} p={2} />
+            )}
+          </Box>
+          <ChainIcon {...{ chain }} mx={2} boxSize="1.5em" />
         </Flex>
         <Heading
           fontWeight="bold"
-          textTransform="uppercase"
+          style={{ fontVariant: 'small-caps' }}
           fontSize="xs"
-          color={daoURL ? 'cyanText' : 'white'}
-          justify="center"
-          align="center"
+          color="cyanText"
+          ml={[0, '1em']}
+          sx={{ textIndent: [0, '-1em'] }}
+          textAlign={['center', 'left']}
+          flexGrow={1}
         >
           {title ?? (
             <Text as={React.Fragment}>
@@ -142,9 +147,8 @@ const MembershipListing: React.FC<MembershipListingProps> = ({
               DAO
             </Text>
           )}
-          <ChainIcon {...{ chain }} mx={2} boxSize={4} />
         </Heading>
-      </HStack>
+      </Flex>
     </ExternalDaoLink>
   );
 };

--- a/packages/web/components/Setup/SetupMemberships.tsx
+++ b/packages/web/components/Setup/SetupMemberships.tsx
@@ -20,7 +20,7 @@ import React, { useState } from 'react';
 import { getDAOLink } from 'utils/daoHelpers';
 
 import { useMounted, useWeb3 } from '../../lib/hooks';
-import { DaoHausLink } from '../Player/PlayerGuild';
+import { ExternalDaoLink } from '../Player/PlayerGuild';
 
 export type SetupMembershipsProps = {
   memberships: Array<Membership> | null | undefined;
@@ -105,14 +105,14 @@ const MembershipListing: React.FC<MembershipListingProps> = ({
   const daoURL = getDAOLink(chain, molochId);
 
   return (
-    <DaoHausLink
-      {...{ daoURL }}
+    <ExternalDaoLink
+      daoURL={daoURL}
       bg="dark"
       border="2px transparent solid"
       _hover={{ borderColor: 'purpleBoxLight' }}
     >
-      <HStack align="center">
-        <Flex bg="purpleBoxLight" width={16} height={16} mr={1}>
+      <HStack alignItems="center" mb={4}>
+        <Flex bg="purpleBoxLight" width={16} height={16} mr={6}>
           {avatarURL ? (
             <Image
               src={avatarURL}
@@ -145,6 +145,6 @@ const MembershipListing: React.FC<MembershipListingProps> = ({
           <ChainIcon {...{ chain }} mx={2} boxSize={4} />
         </Heading>
       </HStack>
-    </DaoHausLink>
+    </ExternalDaoLink>
   );
 };

--- a/packages/web/graphql/fragments.ts
+++ b/packages/web/graphql/fragments.ts
@@ -73,15 +73,15 @@ export const GuildFragment = /* GraphQL */ `
     id
     guildname
     description
-    discord_invite_url
-    join_button_url
+    discordInviteUrl
+    joinButtonUrl
     logo
     name
     type
     position
-    website_url
-    github_url
-    twitter_url
+    websiteUrl
+    githubUrl
+    twitterUrl
     daos {
       contractAddress
       network
@@ -129,6 +129,36 @@ export const QuestFragment = /* GraphQL */ `
   }
 `;
 
+export const QuestCompletionFragment = /* GraphQL */ `
+  fragment QuestCompletionFragment on quest_completion {
+    id
+    completedByPlayerId
+    status
+    submissionLink
+    submissionText
+    submittedAt
+    questId
+    completed {
+      title
+    }
+  }
+`;
+
+export const TokenBalancesFragment = /* GraphQL */ `
+  fragment TokenBalancesFragment on TokenBalances {
+    address: id
+    pSeedBalance
+  }
+`;
+
+export const PlayerSkillFragment = /* GraphQL */ `
+  fragment PlayerSkillFragment on skill {
+    id
+    name
+    category
+  }
+`;
+
 export const QuestWithCompletionFragment = /* GraphQL */ `
   fragment QuestWithCompletionFragment on quest {
     id
@@ -170,35 +200,5 @@ export const QuestWithCompletionFragment = /* GraphQL */ `
         }
       }
     }
-  }
-`;
-
-export const QuestCompletionFragment = /* GraphQL */ `
-  fragment QuestCompletionFragment on quest_completion {
-    id
-    completedByPlayerId
-    status
-    submissionLink
-    submissionText
-    submittedAt
-    questId
-    completed {
-      title
-    }
-  }
-`;
-
-export const TokenBalancesFragment = /* GraphQL */ `
-  fragment TokenBalancesFragment on TokenBalances {
-    address: id
-    pSeedBalance
-  }
-`;
-
-export const PlayerSkillFragment = /* GraphQL */ `
-  fragment PlayerSkillFragment on skill {
-    id
-    name
-    category
   }
 `;

--- a/packages/web/graphql/fragments.ts
+++ b/packages/web/graphql/fragments.ts
@@ -76,13 +76,18 @@ export const GuildFragment = /* GraphQL */ `
     discord_invite_url
     join_button_url
     logo
-    moloch_address
     name
     type
     position
     website_url
     github_url
     twitter_url
+    daos {
+      contractAddress
+      network
+      label
+      url
+    }
   }
 `;
 

--- a/packages/web/graphql/getMemberships.ts
+++ b/packages/web/graphql/getMemberships.ts
@@ -29,10 +29,13 @@ const guildMembershipsQuery = /* GraphQL */ `
       Guild {
         id
         logo
-        moloch_address
         name
         guildname
         membership_through_discord
+        daos {
+          id
+          contractAddress
+        }
       }
       discordRoles {
         id
@@ -82,12 +85,15 @@ export type GuildMembership = {
 export const getAllMemberships = async (player: Player) => {
   const guildPlayers = await getGuildMemberships(player.id);
 
+  // filter out any Daohaus DAOs that are also linked to an existing Guild whose
+  // membership is determined by their Discord server
   const daohausMemberships = player.daohausMemberships?.filter(
     (m) =>
       !guildPlayers?.some(
         (gp) =>
-          gp.Guild.moloch_address === m.molochAddress &&
-          gp.Guild.membership_through_discord === true,
+          gp.Guild.daos.some(
+            (dao) => dao.contractAddress === m.molochAddress,
+          ) && gp.Guild.membership_through_discord === true,
       ),
   );
 

--- a/packages/web/graphql/getMemberships.ts
+++ b/packages/web/graphql/getMemberships.ts
@@ -24,14 +24,14 @@ const daoMembershipsQuery = /* GraphQL */ `
 
 const guildMembershipsQuery = /* GraphQL */ `
   query GetPlayerGuilds($playerId: uuid!) {
-    guild_player(where: { player_id: { _eq: $playerId } }) {
-      guild_id
+    guild_player(where: { playerId: { _eq: $playerId } }) {
+      guildId
       Guild {
         id
         logo
         name
         guildname
-        membership_through_discord
+        membershipThroughDiscord
         daos {
           id
           contractAddress
@@ -93,13 +93,13 @@ export const getAllMemberships = async (player: Player) => {
         (gp) =>
           gp.Guild.daos.some(
             (dao) => dao.contractAddress === m.molochAddress,
-          ) && gp.Guild.membership_through_discord === true,
+          ) && gp.Guild.membershipThroughDiscord === true,
       ),
   );
 
   const memberships: Array<GuildMembership> = [
     ...(guildPlayers || []).map((gp) => ({
-      memberId: `${gp.guild_id}:${player.id}`,
+      memberId: `${gp.guildId}:${player.id}`,
       title: gp.Guild.name,
       guildname: gp.Guild.guildname,
       memberRank: gp.discordRoles[0].name ?? undefined,

--- a/packages/web/graphql/mutations/guild.ts
+++ b/packages/web/graphql/mutations/guild.ts
@@ -11,7 +11,7 @@ export {};
     }
   }
 
-  mutation UpdateGuild($guildInfo: GuildInfo!) {
+  mutation UpdateGuild($guildInfo: GuildInfoInput!) {
     saveGuildInformation(guildInformation: $guildInfo) {
       success
       error

--- a/packages/web/graphql/queries/guild.ts
+++ b/packages/web/graphql/queries/guild.ts
@@ -1,6 +1,4 @@
 import {
-  GetAdministeredGuildsQuery,
-  GetAdministeredGuildsQueryVariables,
   GetGuildMetadataQuery,
   GetGuildMetadataQueryVariables,
   GetGuildnamesQuery,
@@ -65,7 +63,7 @@ export const getGuildMetadata = async (id: string) => {
   return data?.guild_metadata[0];
 };
 
-const getAdministeredGuildsQuery = /* GraphQL */ `
+export const getAdministeredGuildsQuery = /* GraphQL */ `
   query GetAdministeredGuilds($id: uuid!) {
     guild_metadata(where: { creatorId: { _eq: $id } }) {
       guildId
@@ -75,24 +73,6 @@ const getAdministeredGuildsQuery = /* GraphQL */ `
     }
   }
 `;
-
-export const getAdministeredGuilds = async (playerId: string) => {
-  const { data, error } = await client
-    .query<GetAdministeredGuildsQuery, GetAdministeredGuildsQueryVariables>(
-      getAdministeredGuildsQuery,
-      { id: playerId },
-    )
-    .toPromise();
-
-  if (!data) {
-    if (error) {
-      throw error;
-    }
-    return [];
-  }
-
-  return data.guild_metadata.map((gm) => gm.guild);
-};
 
 const guildsQuery = /* GraphQL */ `
   query GetGuilds($limit: Int) {

--- a/packages/web/graphql/queries/guild.ts
+++ b/packages/web/graphql/queries/guild.ts
@@ -1,4 +1,6 @@
 import {
+  GetAdministeredGuildsQuery,
+  GetAdministeredGuildsQueryVariables,
   GetGuildMetadataQuery,
   GetGuildMetadataQueryVariables,
   GetGuildnamesQuery,
@@ -40,9 +42,9 @@ export const getGuild = async (
 
 const guildMetadataQuery = /* GraphQL */ `
   query GetGuildMetadata($id: uuid!) {
-    guild_metadata(where: { guild_id: { _eq: $id } }) {
-      guild_id
-      discord_metadata
+    guild_metadata(where: { guildId: { _eq: $id } }) {
+      guildId
+      discordMetadata
       discordRoles {
         id
         name
@@ -61,6 +63,35 @@ export const getGuildMetadata = async (id: string) => {
     )
     .toPromise();
   return data?.guild_metadata[0];
+};
+
+const getAdministeredGuildsQuery = /* GraphQL */ `
+  query GetAdministeredGuilds($id: uuid!) {
+    guild_metadata(where: { creatorId: { _eq: $id } }) {
+      guildId
+      guild {
+        guildname
+      }
+    }
+  }
+`;
+
+export const getAdministeredGuilds = async (playerId: string) => {
+  const { data, error } = await client
+    .query<GetAdministeredGuildsQuery, GetAdministeredGuildsQueryVariables>(
+      guildsQuery,
+      { id: playerId },
+    )
+    .toPromise();
+
+  if (!data) {
+    if (error) {
+      throw error;
+    }
+    return [];
+  }
+
+  return data.guild_metadata.map((gm) => gm.guild);
 };
 
 const guildsQuery = /* GraphQL */ `
@@ -119,7 +150,7 @@ export const getGuildnames = async (
 
 const getGuildPlayersQuery = /* GraphQL */ `
   query GetGuildPlayers($guildId: uuid!) {
-    guild_player(where: { guild_id: { _eq: $guildId } }) {
+    guild_player(where: { guildId: { _eq: $guildId } }) {
       Player {
         id
         totalXP

--- a/packages/web/graphql/queries/guild.ts
+++ b/packages/web/graphql/queries/guild.ts
@@ -79,7 +79,7 @@ const getAdministeredGuildsQuery = /* GraphQL */ `
 export const getAdministeredGuilds = async (playerId: string) => {
   const { data, error } = await client
     .query<GetAdministeredGuildsQuery, GetAdministeredGuildsQueryVariables>(
-      guildsQuery,
+      getAdministeredGuildsQuery,
       { id: playerId },
     )
     .toPromise();

--- a/packages/web/pages/guild/[guildname].tsx
+++ b/packages/web/pages/guild/[guildname].tsx
@@ -20,7 +20,7 @@ import {
 } from 'next';
 import { useRouter } from 'next/router';
 import Page404 from 'pages/404';
-import React, { useEffect, useState } from 'react';
+import React, { useEffect, useMemo } from 'react';
 import { BoxTypes } from 'utils/boxTypes';
 import { getGuildCoverImageFull } from 'utils/playerHelpers';
 
@@ -30,7 +30,6 @@ const GuildPage: React.FC<Props> = ({ guild }) => {
   const router = useRouter();
   const { user, fetching } = useUser();
   const [getGuildsResult, getGuilds] = useGetAdministeredGuildsQuery();
-  const [canEdit, setCanEdit] = useState<boolean>(false);
 
   useEffect(() => {
     if (!fetching && user) {
@@ -38,16 +37,14 @@ const GuildPage: React.FC<Props> = ({ guild }) => {
     }
   }, [fetching, user, getGuilds]);
 
-  useEffect(() => {
-    if (
+  const canEdit = useMemo(
+    () =>
       user?.id ===
       getGuildsResult?.data?.guild_metadata.some(
         (gm) => gm.guildId === guild?.id,
-      )
-    ) {
-      setCanEdit(true);
-    }
-  }, [user, getGuildsResult, guild]);
+      ),
+    [user, getGuildsResult, guild],
+  );
 
   // Hidden until implemented
   // BoxType.GUILD_SKILLS,

--- a/packages/web/pages/guild/[guildname].tsx
+++ b/packages/web/pages/guild/[guildname].tsx
@@ -104,8 +104,8 @@ const GuildPage: React.FC<Props> = ({ guild }) => {
       <Flex
         w="full"
         minH="100vh"
-        pl={[4, 8, 8]}
-        pr={[4, 8, 8]}
+        pl={[4, 8, 12]}
+        pr={[4, 8, 12]}
         pb={[4, 8, 12]}
         pt={200 - 72}
         direction="column"

--- a/packages/web/pages/join/guild/[guildname].tsx
+++ b/packages/web/pages/join/guild/[guildname].tsx
@@ -3,7 +3,7 @@ import { FlexContainer, PageContainer } from 'components/Container';
 import { EditGuildFormInputs, GuildForm } from 'components/Guild/GuildForm';
 import {
   GuildFragment,
-  GuildInfo,
+  GuildInfoInput,
   GuildType_ActionEnum,
   useUpdateGuildMutation,
 } from 'graphql/autogen/types';
@@ -41,7 +41,7 @@ const SetupGuild: React.FC = () => {
       ...otherInputs
     } = editGuildFormInputs;
 
-    const payload: GuildInfo = {
+    const payload: GuildInfoInput = {
       ...otherInputs,
       discordAdminRoles: adminRoles.map((o) => o.value),
       discordMembershipRoles: membershipRoles.map((o) => o.value),

--- a/schema.graphql
+++ b/schema.graphql
@@ -2367,7 +2367,7 @@ input GuildDao {
 }
 
 input GuildInfo {
-  daos: [GuildDao]
+  daos: [GuildDao!]
   description: String
   discordAdminRoles: [String]!
   discordInviteURL: String

--- a/schema.graphql
+++ b/schema.graphql
@@ -592,11 +592,50 @@ type CreateQuestOutput {
 columns and relationships of "dao"
 """
 type dao {
-  contract_address: String!
-  guild_id: uuid
+  contractAddress: String!
+
+  """An object relationship"""
+  guild: guild
+  guildId: uuid
   id: uuid!
   label: String
   network: String!
+
+  """An array relationship"""
+  players(
+    """distinct select on columns"""
+    distinct_on: [dao_player_select_column!]
+
+    """limit the number of rows returned"""
+    limit: Int
+
+    """skip the first n rows. Use only with order_by"""
+    offset: Int
+
+    """sort the rows by one or more columns"""
+    order_by: [dao_player_order_by!]
+
+    """filter the rows returned"""
+    where: dao_player_bool_exp
+  ): [dao_player!]!
+
+  """An aggregated array relationship"""
+  players_aggregate(
+    """distinct select on columns"""
+    distinct_on: [dao_player_select_column!]
+
+    """limit the number of rows returned"""
+    limit: Int
+
+    """skip the first n rows. Use only with order_by"""
+    offset: Int
+
+    """sort the rows by one or more columns"""
+    order_by: [dao_player_order_by!]
+
+    """filter the rows returned"""
+    where: dao_player_bool_exp
+  ): dao_player_aggregate!
   url: String
 }
 
@@ -641,11 +680,13 @@ input dao_bool_exp {
   _and: [dao_bool_exp]
   _not: dao_bool_exp
   _or: [dao_bool_exp]
-  contract_address: String_comparison_exp
-  guild_id: uuid_comparison_exp
+  contractAddress: String_comparison_exp
+  guild: guild_bool_exp
+  guildId: uuid_comparison_exp
   id: uuid_comparison_exp
   label: String_comparison_exp
   network: String_comparison_exp
+  players: dao_player_bool_exp
   url: String_comparison_exp
 }
 
@@ -657,9 +698,6 @@ enum dao_constraint {
   dao_contract_address_key
 
   """unique or primary key constraint"""
-  dao_id_key
-
-  """unique or primary key constraint"""
   dao_pkey
 }
 
@@ -667,18 +705,20 @@ enum dao_constraint {
 input type for inserting data into table "dao"
 """
 input dao_insert_input {
-  contract_address: String
-  guild_id: uuid
+  contractAddress: String
+  guild: guild_obj_rel_insert_input
+  guildId: uuid
   id: uuid
   label: String
   network: String
+  players: dao_player_arr_rel_insert_input
   url: String
 }
 
 """aggregate max on columns"""
 type dao_max_fields {
-  contract_address: String
-  guild_id: uuid
+  contractAddress: String
+  guildId: uuid
   id: uuid
   label: String
   network: String
@@ -689,8 +729,8 @@ type dao_max_fields {
 order by max() on columns of table "dao"
 """
 input dao_max_order_by {
-  contract_address: order_by
-  guild_id: order_by
+  contractAddress: order_by
+  guildId: order_by
   id: order_by
   label: order_by
   network: order_by
@@ -699,8 +739,8 @@ input dao_max_order_by {
 
 """aggregate min on columns"""
 type dao_min_fields {
-  contract_address: String
-  guild_id: uuid
+  contractAddress: String
+  guildId: uuid
   id: uuid
   label: String
   network: String
@@ -711,8 +751,8 @@ type dao_min_fields {
 order by min() on columns of table "dao"
 """
 input dao_min_order_by {
-  contract_address: order_by
-  guild_id: order_by
+  contractAddress: order_by
+  guildId: order_by
   id: order_by
   label: order_by
   network: order_by
@@ -751,11 +791,13 @@ input dao_on_conflict {
 ordering options when selecting data from "dao"
 """
 input dao_order_by {
-  contract_address: order_by
-  guild_id: order_by
+  contractAddress: order_by
+  guild: guild_order_by
+  guildId: order_by
   id: order_by
   label: order_by
   network: order_by
+  players_aggregate: dao_player_aggregate_order_by
   url: order_by
 }
 
@@ -770,8 +812,9 @@ input dao_pk_columns_input {
 columns and relationships of "dao_player"
 """
 type dao_player {
-  dao_id: uuid!
-  player_id: uuid!
+  daoId: uuid!
+  playerId: uuid!
+  visible: Boolean
 }
 
 """
@@ -815,8 +858,9 @@ input dao_player_bool_exp {
   _and: [dao_player_bool_exp]
   _not: dao_player_bool_exp
   _or: [dao_player_bool_exp]
-  dao_id: uuid_comparison_exp
-  player_id: uuid_comparison_exp
+  daoId: uuid_comparison_exp
+  playerId: uuid_comparison_exp
+  visible: Boolean_comparison_exp
 }
 
 """
@@ -831,36 +875,37 @@ enum dao_player_constraint {
 input type for inserting data into table "dao_player"
 """
 input dao_player_insert_input {
-  dao_id: uuid
-  player_id: uuid
+  daoId: uuid
+  playerId: uuid
+  visible: Boolean
 }
 
 """aggregate max on columns"""
 type dao_player_max_fields {
-  dao_id: uuid
-  player_id: uuid
+  daoId: uuid
+  playerId: uuid
 }
 
 """
 order by max() on columns of table "dao_player"
 """
 input dao_player_max_order_by {
-  dao_id: order_by
-  player_id: order_by
+  daoId: order_by
+  playerId: order_by
 }
 
 """aggregate min on columns"""
 type dao_player_min_fields {
-  dao_id: uuid
-  player_id: uuid
+  daoId: uuid
+  playerId: uuid
 }
 
 """
 order by min() on columns of table "dao_player"
 """
 input dao_player_min_order_by {
-  dao_id: order_by
-  player_id: order_by
+  daoId: order_by
+  playerId: order_by
 }
 
 """
@@ -895,16 +940,17 @@ input dao_player_on_conflict {
 ordering options when selecting data from "dao_player"
 """
 input dao_player_order_by {
-  dao_id: order_by
-  player_id: order_by
+  daoId: order_by
+  playerId: order_by
+  visible: order_by
 }
 
 """
 primary key columns input for table: "dao_player"
 """
 input dao_player_pk_columns_input {
-  dao_id: uuid!
-  player_id: uuid!
+  daoId: uuid!
+  playerId: uuid!
 }
 
 """
@@ -912,18 +958,22 @@ select columns of table "dao_player"
 """
 enum dao_player_select_column {
   """column name"""
-  dao_id
+  daoId
 
   """column name"""
-  player_id
+  playerId
+
+  """column name"""
+  visible
 }
 
 """
 input type for updating data in table "dao_player"
 """
 input dao_player_set_input {
-  dao_id: uuid
-  player_id: uuid
+  daoId: uuid
+  playerId: uuid
+  visible: Boolean
 }
 
 """
@@ -931,10 +981,13 @@ update columns of table "dao_player"
 """
 enum dao_player_update_column {
   """column name"""
-  dao_id
+  daoId
 
   """column name"""
-  player_id
+  playerId
+
+  """column name"""
+  visible
 }
 
 """
@@ -942,10 +995,10 @@ select columns of table "dao"
 """
 enum dao_select_column {
   """column name"""
-  contract_address
+  contractAddress
 
   """column name"""
-  guild_id
+  guildId
 
   """column name"""
   id
@@ -964,8 +1017,8 @@ enum dao_select_column {
 input type for updating data in table "dao"
 """
 input dao_set_input {
-  contract_address: String
-  guild_id: uuid
+  contractAddress: String
+  guildId: uuid
   id: uuid
   label: String
   network: String
@@ -977,10 +1030,10 @@ update columns of table "dao"
 """
 enum dao_update_column {
   """column name"""
-  contract_address
+  contractAddress
 
   """column name"""
-  guild_id
+  guildId
 
   """column name"""
   id
@@ -1390,6 +1443,42 @@ columns and relationships of "guild"
 type guild {
   """An object relationship"""
   GuildType: GuildType!
+
+  """An array relationship"""
+  daos(
+    """distinct select on columns"""
+    distinct_on: [dao_select_column!]
+
+    """limit the number of rows returned"""
+    limit: Int
+
+    """skip the first n rows. Use only with order_by"""
+    offset: Int
+
+    """sort the rows by one or more columns"""
+    order_by: [dao_order_by!]
+
+    """filter the rows returned"""
+    where: dao_bool_exp
+  ): [dao!]!
+
+  """An aggregated array relationship"""
+  daos_aggregate(
+    """distinct select on columns"""
+    distinct_on: [dao_select_column!]
+
+    """limit the number of rows returned"""
+    limit: Int
+
+    """skip the first n rows. Use only with order_by"""
+    offset: Int
+
+    """sort the rows by one or more columns"""
+    order_by: [dao_order_by!]
+
+    """filter the rows returned"""
+    where: dao_bool_exp
+  ): dao_aggregate!
   description: String
   discord_id: String
   discord_invite_url: String
@@ -1440,7 +1529,6 @@ type guild {
 
   """An object relationship"""
   metadata: guild_metadata
-  moloch_address: String
   name: String!
   position: GuildPosition_enum
 
@@ -1529,6 +1617,7 @@ input guild_bool_exp {
   _and: [guild_bool_exp]
   _not: guild_bool_exp
   _or: [guild_bool_exp]
+  daos: dao_bool_exp
   description: String_comparison_exp
   discord_id: String_comparison_exp
   discord_invite_url: String_comparison_exp
@@ -1540,7 +1629,6 @@ input guild_bool_exp {
   logo: String_comparison_exp
   membership_through_discord: Boolean_comparison_exp
   metadata: guild_metadata_bool_exp
-  moloch_address: String_comparison_exp
   name: String_comparison_exp
   position: GuildPosition_enum_comparison_exp
   quests: quest_bool_exp
@@ -1569,6 +1657,7 @@ input type for inserting data into table "guild"
 """
 input guild_insert_input {
   GuildType: GuildType_obj_rel_insert_input
+  daos: dao_arr_rel_insert_input
   description: String
   discord_id: String
   discord_invite_url: String
@@ -1580,7 +1669,6 @@ input guild_insert_input {
   logo: String
   membership_through_discord: Boolean
   metadata: guild_metadata_obj_rel_insert_input
-  moloch_address: String
   name: String
   position: GuildPosition_enum
   quests: quest_arr_rel_insert_input
@@ -1600,7 +1688,6 @@ type guild_max_fields {
   id: uuid
   join_button_url: String
   logo: String
-  moloch_address: String
   name: String
   twitter_url: String
   website_url: String
@@ -1618,7 +1705,6 @@ input guild_max_order_by {
   id: order_by
   join_button_url: order_by
   logo: order_by
-  moloch_address: order_by
   name: order_by
   twitter_url: order_by
   website_url: order_by
@@ -1884,7 +1970,6 @@ type guild_min_fields {
   id: uuid
   join_button_url: String
   logo: String
-  moloch_address: String
   name: String
   twitter_url: String
   website_url: String
@@ -1902,7 +1987,6 @@ input guild_min_order_by {
   id: order_by
   join_button_url: order_by
   logo: order_by
-  moloch_address: order_by
   name: order_by
   twitter_url: order_by
   website_url: order_by
@@ -1941,6 +2025,7 @@ ordering options when selecting data from "guild"
 """
 input guild_order_by {
   GuildType: GuildType_order_by
+  daos_aggregate: dao_aggregate_order_by
   description: order_by
   discord_id: order_by
   discord_invite_url: order_by
@@ -1952,7 +2037,6 @@ input guild_order_by {
   logo: order_by
   membership_through_discord: order_by
   metadata: guild_metadata_order_by
-  moloch_address: order_by
   name: order_by
   position: order_by
   quests_aggregate: quest_aggregate_order_by
@@ -2186,9 +2270,6 @@ enum guild_select_column {
   membership_through_discord
 
   """column name"""
-  moloch_address
-
-  """column name"""
   name
 
   """column name"""
@@ -2220,7 +2301,6 @@ input guild_set_input {
   join_button_url: String
   logo: String
   membership_through_discord: Boolean
-  moloch_address: String
   name: String
   position: GuildPosition_enum
   status: GuildStatus_enum
@@ -2261,9 +2341,6 @@ enum guild_update_column {
   membership_through_discord
 
   """column name"""
-  moloch_address
-
-  """column name"""
   name
 
   """column name"""
@@ -2282,8 +2359,15 @@ enum guild_update_column {
   website_url
 }
 
+input GuildDao {
+  contractAddress: String!
+  label: String
+  network: String!
+  url: String
+}
+
 input GuildInfo {
-  daoAddress: String
+  daos: [GuildDao]
   description: String
   discordAdminRoles: [String]!
   discordInviteURL: String
@@ -3254,7 +3338,7 @@ type mutation_root {
   """
   delete single row from the table: "dao_player"
   """
-  delete_dao_player_by_pk(dao_id: uuid!, player_id: uuid!): dao_player
+  delete_dao_player_by_pk(daoId: uuid!, playerId: uuid!): dao_player
 
   """
   delete data from the table: "guild"
@@ -7762,7 +7846,7 @@ type query_root {
   ): dao_player_aggregate!
 
   """fetch data from the table: "dao_player" using primary key columns"""
-  dao_player_by_pk(dao_id: uuid!, player_id: uuid!): dao_player
+  dao_player_by_pk(daoId: uuid!, playerId: uuid!): dao_player
   getBrightIdStatus(contextId: uuid): BrightIdStatus
   getDaoHausMemberships(memberAddress: String): [Member!]!
   getDiscordServerMemberRoles(guildId: uuid!, playerId: uuid!): [DiscordRole!]!
@@ -11385,7 +11469,7 @@ type subscription_root {
   ): dao_player_aggregate!
 
   """fetch data from the table: "dao_player" using primary key columns"""
-  dao_player_by_pk(dao_id: uuid!, player_id: uuid!): dao_player
+  dao_player_by_pk(daoId: uuid!, playerId: uuid!): dao_player
 
   """
   fetch data from the table: "guild"

--- a/schema.graphql
+++ b/schema.graphql
@@ -589,6 +589,413 @@ type CreateQuestOutput {
 }
 
 """
+columns and relationships of "dao"
+"""
+type dao {
+  contract_address: String!
+  guild_id: uuid
+  id: uuid!
+  label: String
+  network: String!
+  url: String
+}
+
+"""
+aggregated selection of "dao"
+"""
+type dao_aggregate {
+  aggregate: dao_aggregate_fields
+  nodes: [dao!]!
+}
+
+"""
+aggregate fields of "dao"
+"""
+type dao_aggregate_fields {
+  count(columns: [dao_select_column!], distinct: Boolean): Int
+  max: dao_max_fields
+  min: dao_min_fields
+}
+
+"""
+order by aggregate values of table "dao"
+"""
+input dao_aggregate_order_by {
+  count: order_by
+  max: dao_max_order_by
+  min: dao_min_order_by
+}
+
+"""
+input type for inserting array relation for remote table "dao"
+"""
+input dao_arr_rel_insert_input {
+  data: [dao_insert_input!]!
+  on_conflict: dao_on_conflict
+}
+
+"""
+Boolean expression to filter rows from the table "dao". All fields are combined with a logical 'AND'.
+"""
+input dao_bool_exp {
+  _and: [dao_bool_exp]
+  _not: dao_bool_exp
+  _or: [dao_bool_exp]
+  contract_address: String_comparison_exp
+  guild_id: uuid_comparison_exp
+  id: uuid_comparison_exp
+  label: String_comparison_exp
+  network: String_comparison_exp
+  url: String_comparison_exp
+}
+
+"""
+unique or primary key constraints on table "dao"
+"""
+enum dao_constraint {
+  """unique or primary key constraint"""
+  dao_contract_address_key
+
+  """unique or primary key constraint"""
+  dao_id_key
+
+  """unique or primary key constraint"""
+  dao_pkey
+}
+
+"""
+input type for inserting data into table "dao"
+"""
+input dao_insert_input {
+  contract_address: String
+  guild_id: uuid
+  id: uuid
+  label: String
+  network: String
+  url: String
+}
+
+"""aggregate max on columns"""
+type dao_max_fields {
+  contract_address: String
+  guild_id: uuid
+  id: uuid
+  label: String
+  network: String
+  url: String
+}
+
+"""
+order by max() on columns of table "dao"
+"""
+input dao_max_order_by {
+  contract_address: order_by
+  guild_id: order_by
+  id: order_by
+  label: order_by
+  network: order_by
+  url: order_by
+}
+
+"""aggregate min on columns"""
+type dao_min_fields {
+  contract_address: String
+  guild_id: uuid
+  id: uuid
+  label: String
+  network: String
+  url: String
+}
+
+"""
+order by min() on columns of table "dao"
+"""
+input dao_min_order_by {
+  contract_address: order_by
+  guild_id: order_by
+  id: order_by
+  label: order_by
+  network: order_by
+  url: order_by
+}
+
+"""
+response of any mutation on the table "dao"
+"""
+type dao_mutation_response {
+  """number of affected rows by the mutation"""
+  affected_rows: Int!
+
+  """data of the affected rows by the mutation"""
+  returning: [dao!]!
+}
+
+"""
+input type for inserting object relation for remote table "dao"
+"""
+input dao_obj_rel_insert_input {
+  data: dao_insert_input!
+  on_conflict: dao_on_conflict
+}
+
+"""
+on conflict condition type for table "dao"
+"""
+input dao_on_conflict {
+  constraint: dao_constraint!
+  update_columns: [dao_update_column!]!
+  where: dao_bool_exp
+}
+
+"""
+ordering options when selecting data from "dao"
+"""
+input dao_order_by {
+  contract_address: order_by
+  guild_id: order_by
+  id: order_by
+  label: order_by
+  network: order_by
+  url: order_by
+}
+
+"""
+primary key columns input for table: "dao"
+"""
+input dao_pk_columns_input {
+  id: uuid!
+}
+
+"""
+columns and relationships of "dao_player"
+"""
+type dao_player {
+  dao_id: uuid!
+  player_id: uuid!
+}
+
+"""
+aggregated selection of "dao_player"
+"""
+type dao_player_aggregate {
+  aggregate: dao_player_aggregate_fields
+  nodes: [dao_player!]!
+}
+
+"""
+aggregate fields of "dao_player"
+"""
+type dao_player_aggregate_fields {
+  count(columns: [dao_player_select_column!], distinct: Boolean): Int
+  max: dao_player_max_fields
+  min: dao_player_min_fields
+}
+
+"""
+order by aggregate values of table "dao_player"
+"""
+input dao_player_aggregate_order_by {
+  count: order_by
+  max: dao_player_max_order_by
+  min: dao_player_min_order_by
+}
+
+"""
+input type for inserting array relation for remote table "dao_player"
+"""
+input dao_player_arr_rel_insert_input {
+  data: [dao_player_insert_input!]!
+  on_conflict: dao_player_on_conflict
+}
+
+"""
+Boolean expression to filter rows from the table "dao_player". All fields are combined with a logical 'AND'.
+"""
+input dao_player_bool_exp {
+  _and: [dao_player_bool_exp]
+  _not: dao_player_bool_exp
+  _or: [dao_player_bool_exp]
+  dao_id: uuid_comparison_exp
+  player_id: uuid_comparison_exp
+}
+
+"""
+unique or primary key constraints on table "dao_player"
+"""
+enum dao_player_constraint {
+  """unique or primary key constraint"""
+  dao_player_pkey
+}
+
+"""
+input type for inserting data into table "dao_player"
+"""
+input dao_player_insert_input {
+  dao_id: uuid
+  player_id: uuid
+}
+
+"""aggregate max on columns"""
+type dao_player_max_fields {
+  dao_id: uuid
+  player_id: uuid
+}
+
+"""
+order by max() on columns of table "dao_player"
+"""
+input dao_player_max_order_by {
+  dao_id: order_by
+  player_id: order_by
+}
+
+"""aggregate min on columns"""
+type dao_player_min_fields {
+  dao_id: uuid
+  player_id: uuid
+}
+
+"""
+order by min() on columns of table "dao_player"
+"""
+input dao_player_min_order_by {
+  dao_id: order_by
+  player_id: order_by
+}
+
+"""
+response of any mutation on the table "dao_player"
+"""
+type dao_player_mutation_response {
+  """number of affected rows by the mutation"""
+  affected_rows: Int!
+
+  """data of the affected rows by the mutation"""
+  returning: [dao_player!]!
+}
+
+"""
+input type for inserting object relation for remote table "dao_player"
+"""
+input dao_player_obj_rel_insert_input {
+  data: dao_player_insert_input!
+  on_conflict: dao_player_on_conflict
+}
+
+"""
+on conflict condition type for table "dao_player"
+"""
+input dao_player_on_conflict {
+  constraint: dao_player_constraint!
+  update_columns: [dao_player_update_column!]!
+  where: dao_player_bool_exp
+}
+
+"""
+ordering options when selecting data from "dao_player"
+"""
+input dao_player_order_by {
+  dao_id: order_by
+  player_id: order_by
+}
+
+"""
+primary key columns input for table: "dao_player"
+"""
+input dao_player_pk_columns_input {
+  dao_id: uuid!
+  player_id: uuid!
+}
+
+"""
+select columns of table "dao_player"
+"""
+enum dao_player_select_column {
+  """column name"""
+  dao_id
+
+  """column name"""
+  player_id
+}
+
+"""
+input type for updating data in table "dao_player"
+"""
+input dao_player_set_input {
+  dao_id: uuid
+  player_id: uuid
+}
+
+"""
+update columns of table "dao_player"
+"""
+enum dao_player_update_column {
+  """column name"""
+  dao_id
+
+  """column name"""
+  player_id
+}
+
+"""
+select columns of table "dao"
+"""
+enum dao_select_column {
+  """column name"""
+  contract_address
+
+  """column name"""
+  guild_id
+
+  """column name"""
+  id
+
+  """column name"""
+  label
+
+  """column name"""
+  network
+
+  """column name"""
+  url
+}
+
+"""
+input type for updating data in table "dao"
+"""
+input dao_set_input {
+  contract_address: String
+  guild_id: uuid
+  id: uuid
+  label: String
+  network: String
+  url: String
+}
+
+"""
+update columns of table "dao"
+"""
+enum dao_update_column {
+  """column name"""
+  contract_address
+
+  """column name"""
+  guild_id
+
+  """column name"""
+  id
+
+  """column name"""
+  label
+
+  """column name"""
+  network
+
+  """column name"""
+  url
+}
+
+"""
 e.g. https://data.daohaus.club/dao/0xb152b115c94275b54a3f0b08c1aa1d21f32a659a
 """
 type DaoMetadata {
@@ -2824,6 +3231,32 @@ type mutation_root {
   delete_SkillCategory_by_pk(name: String!): SkillCategory
 
   """
+  delete data from the table: "dao"
+  """
+  delete_dao(
+    """filter the rows which have to be deleted"""
+    where: dao_bool_exp!
+  ): dao_mutation_response
+
+  """
+  delete single row from the table: "dao"
+  """
+  delete_dao_by_pk(id: uuid!): dao
+
+  """
+  delete data from the table: "dao_player"
+  """
+  delete_dao_player(
+    """filter the rows which have to be deleted"""
+    where: dao_player_bool_exp!
+  ): dao_player_mutation_response
+
+  """
+  delete single row from the table: "dao_player"
+  """
+  delete_dao_player_by_pk(dao_id: uuid!, player_id: uuid!): dao_player
+
+  """
   delete data from the table: "guild"
   """
   delete_guild(
@@ -3250,6 +3683,50 @@ type mutation_root {
     """on conflict condition"""
     on_conflict: SkillCategory_on_conflict
   ): SkillCategory
+
+  """
+  insert data into the table: "dao"
+  """
+  insert_dao(
+    """the rows to be inserted"""
+    objects: [dao_insert_input!]!
+
+    """on conflict condition"""
+    on_conflict: dao_on_conflict
+  ): dao_mutation_response
+
+  """
+  insert a single row into the table: "dao"
+  """
+  insert_dao_one(
+    """the row to be inserted"""
+    object: dao_insert_input!
+
+    """on conflict condition"""
+    on_conflict: dao_on_conflict
+  ): dao
+
+  """
+  insert data into the table: "dao_player"
+  """
+  insert_dao_player(
+    """the rows to be inserted"""
+    objects: [dao_player_insert_input!]!
+
+    """on conflict condition"""
+    on_conflict: dao_player_on_conflict
+  ): dao_player_mutation_response
+
+  """
+  insert a single row into the table: "dao_player"
+  """
+  insert_dao_player_one(
+    """the row to be inserted"""
+    object: dao_player_insert_input!
+
+    """on conflict condition"""
+    on_conflict: dao_player_on_conflict
+  ): dao_player
 
   """
   insert data into the table: "guild"
@@ -3808,6 +4285,46 @@ type mutation_root {
     _set: SkillCategory_set_input
     pk_columns: SkillCategory_pk_columns_input!
   ): SkillCategory
+
+  """
+  update data of the table: "dao"
+  """
+  update_dao(
+    """sets the columns of the filtered rows to the given values"""
+    _set: dao_set_input
+
+    """filter the rows which have to be updated"""
+    where: dao_bool_exp!
+  ): dao_mutation_response
+
+  """
+  update single row of the table: "dao"
+  """
+  update_dao_by_pk(
+    """sets the columns of the filtered rows to the given values"""
+    _set: dao_set_input
+    pk_columns: dao_pk_columns_input!
+  ): dao
+
+  """
+  update data of the table: "dao_player"
+  """
+  update_dao_player(
+    """sets the columns of the filtered rows to the given values"""
+    _set: dao_player_set_input
+
+    """filter the rows which have to be updated"""
+    where: dao_player_bool_exp!
+  ): dao_player_mutation_response
+
+  """
+  update single row of the table: "dao_player"
+  """
+  update_dao_player_by_pk(
+    """sets the columns of the filtered rows to the given values"""
+    _set: dao_player_set_input
+    pk_columns: dao_player_pk_columns_input!
+  ): dao_player
 
   """
   update data of the table: "guild"
@@ -7160,6 +7677,92 @@ type query_root {
 
   """fetch data from the table: "SkillCategory" using primary key columns"""
   SkillCategory_by_pk(name: String!): SkillCategory
+
+  """
+  fetch data from the table: "dao"
+  """
+  dao(
+    """distinct select on columns"""
+    distinct_on: [dao_select_column!]
+
+    """limit the number of rows returned"""
+    limit: Int
+
+    """skip the first n rows. Use only with order_by"""
+    offset: Int
+
+    """sort the rows by one or more columns"""
+    order_by: [dao_order_by!]
+
+    """filter the rows returned"""
+    where: dao_bool_exp
+  ): [dao!]!
+
+  """
+  fetch aggregated fields from the table: "dao"
+  """
+  dao_aggregate(
+    """distinct select on columns"""
+    distinct_on: [dao_select_column!]
+
+    """limit the number of rows returned"""
+    limit: Int
+
+    """skip the first n rows. Use only with order_by"""
+    offset: Int
+
+    """sort the rows by one or more columns"""
+    order_by: [dao_order_by!]
+
+    """filter the rows returned"""
+    where: dao_bool_exp
+  ): dao_aggregate!
+
+  """fetch data from the table: "dao" using primary key columns"""
+  dao_by_pk(id: uuid!): dao
+
+  """
+  fetch data from the table: "dao_player"
+  """
+  dao_player(
+    """distinct select on columns"""
+    distinct_on: [dao_player_select_column!]
+
+    """limit the number of rows returned"""
+    limit: Int
+
+    """skip the first n rows. Use only with order_by"""
+    offset: Int
+
+    """sort the rows by one or more columns"""
+    order_by: [dao_player_order_by!]
+
+    """filter the rows returned"""
+    where: dao_player_bool_exp
+  ): [dao_player!]!
+
+  """
+  fetch aggregated fields from the table: "dao_player"
+  """
+  dao_player_aggregate(
+    """distinct select on columns"""
+    distinct_on: [dao_player_select_column!]
+
+    """limit the number of rows returned"""
+    limit: Int
+
+    """skip the first n rows. Use only with order_by"""
+    offset: Int
+
+    """sort the rows by one or more columns"""
+    order_by: [dao_player_order_by!]
+
+    """filter the rows returned"""
+    where: dao_player_bool_exp
+  ): dao_player_aggregate!
+
+  """fetch data from the table: "dao_player" using primary key columns"""
+  dao_player_by_pk(dao_id: uuid!, player_id: uuid!): dao_player
   getBrightIdStatus(contextId: uuid): BrightIdStatus
   getDaoHausMemberships(memberAddress: String): [Member!]!
   getDiscordServerMemberRoles(guildId: uuid!, playerId: uuid!): [DiscordRole!]!
@@ -10697,6 +11300,92 @@ type subscription_root {
 
   """fetch data from the table: "SkillCategory" using primary key columns"""
   SkillCategory_by_pk(name: String!): SkillCategory
+
+  """
+  fetch data from the table: "dao"
+  """
+  dao(
+    """distinct select on columns"""
+    distinct_on: [dao_select_column!]
+
+    """limit the number of rows returned"""
+    limit: Int
+
+    """skip the first n rows. Use only with order_by"""
+    offset: Int
+
+    """sort the rows by one or more columns"""
+    order_by: [dao_order_by!]
+
+    """filter the rows returned"""
+    where: dao_bool_exp
+  ): [dao!]!
+
+  """
+  fetch aggregated fields from the table: "dao"
+  """
+  dao_aggregate(
+    """distinct select on columns"""
+    distinct_on: [dao_select_column!]
+
+    """limit the number of rows returned"""
+    limit: Int
+
+    """skip the first n rows. Use only with order_by"""
+    offset: Int
+
+    """sort the rows by one or more columns"""
+    order_by: [dao_order_by!]
+
+    """filter the rows returned"""
+    where: dao_bool_exp
+  ): dao_aggregate!
+
+  """fetch data from the table: "dao" using primary key columns"""
+  dao_by_pk(id: uuid!): dao
+
+  """
+  fetch data from the table: "dao_player"
+  """
+  dao_player(
+    """distinct select on columns"""
+    distinct_on: [dao_player_select_column!]
+
+    """limit the number of rows returned"""
+    limit: Int
+
+    """skip the first n rows. Use only with order_by"""
+    offset: Int
+
+    """sort the rows by one or more columns"""
+    order_by: [dao_player_order_by!]
+
+    """filter the rows returned"""
+    where: dao_player_bool_exp
+  ): [dao_player!]!
+
+  """
+  fetch aggregated fields from the table: "dao_player"
+  """
+  dao_player_aggregate(
+    """distinct select on columns"""
+    distinct_on: [dao_player_select_column!]
+
+    """limit the number of rows returned"""
+    limit: Int
+
+    """skip the first n rows. Use only with order_by"""
+    offset: Int
+
+    """sort the rows by one or more columns"""
+    order_by: [dao_player_order_by!]
+
+    """filter the rows returned"""
+    where: dao_player_bool_exp
+  ): dao_player_aggregate!
+
+  """fetch data from the table: "dao_player" using primary key columns"""
+  dao_player_by_pk(dao_id: uuid!, player_id: uuid!): dao_player
 
   """
   fetch data from the table: "guild"

--- a/schema.graphql
+++ b/schema.graphql
@@ -4826,6 +4826,42 @@ type player {
 
   """Remote relationship field"""
   daohausMemberships: [Member!]!
+
+  """An array relationship"""
+  daos(
+    """distinct select on columns"""
+    distinct_on: [dao_player_select_column!]
+
+    """limit the number of rows returned"""
+    limit: Int
+
+    """skip the first n rows. Use only with order_by"""
+    offset: Int
+
+    """sort the rows by one or more columns"""
+    order_by: [dao_player_order_by!]
+
+    """filter the rows returned"""
+    where: dao_player_bool_exp
+  ): [dao_player!]!
+
+  """An aggregated array relationship"""
+  daos_aggregate(
+    """distinct select on columns"""
+    distinct_on: [dao_player_select_column!]
+
+    """limit the number of rows returned"""
+    limit: Int
+
+    """skip the first n rows. Use only with order_by"""
+    offset: Int
+
+    """sort the rows by one or more columns"""
+    order_by: [dao_player_order_by!]
+
+    """filter the rows returned"""
+    where: dao_player_bool_exp
+  ): dao_player_aggregate!
   discordId: String
   ethereumAddress: String!
 
@@ -5275,6 +5311,7 @@ input player_bool_exp {
   _or: [player_bool_exp]
   accounts: player_account_bool_exp
   createdAt: timestamptz_comparison_exp
+  daos: dao_player_bool_exp
   discordId: String_comparison_exp
   ethereumAddress: String_comparison_exp
   guilds: guild_player_bool_exp
@@ -5320,6 +5357,7 @@ input type for inserting data into table "player"
 input player_insert_input {
   accounts: player_account_arr_rel_insert_input
   createdAt: timestamptz
+  daos: dao_player_arr_rel_insert_input
   discordId: String
   ethereumAddress: String
   guilds: guild_player_arr_rel_insert_input
@@ -5427,6 +5465,7 @@ ordering options when selecting data from "player"
 input player_order_by {
   accounts_aggregate: player_account_aggregate_order_by
   createdAt: order_by
+  daos_aggregate: dao_player_aggregate_order_by
   discordId: order_by
   ethereumAddress: order_by
   guilds_aggregate: guild_player_aggregate_order_by

--- a/schema.graphql
+++ b/schema.graphql
@@ -1480,9 +1480,9 @@ type guild {
     where: dao_bool_exp
   ): dao_aggregate!
   description: String
-  discord_id: String
-  discord_invite_url: String
-  github_url: String
+  discordId: String
+  discordInviteUrl: String
+  githubUrl: String
 
   """An array relationship"""
   guild_players(
@@ -1523,9 +1523,9 @@ type guild {
   """Unique friendly identifier for the Guild (used in URL)"""
   guildname: String!
   id: uuid!
-  join_button_url: String
+  joinButtonUrl: String
   logo: String
-  membership_through_discord: Boolean!
+  membershipThroughDiscord: Boolean!
 
   """An object relationship"""
   metadata: guild_metadata
@@ -1568,11 +1568,11 @@ type guild {
     where: quest_bool_exp
   ): quest_aggregate!
   status: GuildStatus_enum!
-  twitter_url: String
+  twitterUrl: String
 
   """The area of focus for the guild (e.g. funding, project, etc)"""
   type: GuildType_enum!
-  website_url: String
+  websiteUrl: String
 }
 
 """
@@ -1619,23 +1619,23 @@ input guild_bool_exp {
   _or: [guild_bool_exp]
   daos: dao_bool_exp
   description: String_comparison_exp
-  discord_id: String_comparison_exp
-  discord_invite_url: String_comparison_exp
-  github_url: String_comparison_exp
+  discordId: String_comparison_exp
+  discordInviteUrl: String_comparison_exp
+  githubUrl: String_comparison_exp
   guild_players: guild_player_bool_exp
   guildname: String_comparison_exp
   id: uuid_comparison_exp
-  join_button_url: String_comparison_exp
+  joinButtonUrl: String_comparison_exp
   logo: String_comparison_exp
-  membership_through_discord: Boolean_comparison_exp
+  membershipThroughDiscord: Boolean_comparison_exp
   metadata: guild_metadata_bool_exp
   name: String_comparison_exp
   position: GuildPosition_enum_comparison_exp
   quests: quest_bool_exp
   status: GuildStatus_enum_comparison_exp
-  twitter_url: String_comparison_exp
+  twitterUrl: String_comparison_exp
   type: GuildType_enum_comparison_exp
-  website_url: String_comparison_exp
+  websiteUrl: String_comparison_exp
 }
 
 """
@@ -1659,38 +1659,38 @@ input guild_insert_input {
   GuildType: GuildType_obj_rel_insert_input
   daos: dao_arr_rel_insert_input
   description: String
-  discord_id: String
-  discord_invite_url: String
-  github_url: String
+  discordId: String
+  discordInviteUrl: String
+  githubUrl: String
   guild_players: guild_player_arr_rel_insert_input
   guildname: String
   id: uuid
-  join_button_url: String
+  joinButtonUrl: String
   logo: String
-  membership_through_discord: Boolean
+  membershipThroughDiscord: Boolean
   metadata: guild_metadata_obj_rel_insert_input
   name: String
   position: GuildPosition_enum
   quests: quest_arr_rel_insert_input
   status: GuildStatus_enum
-  twitter_url: String
+  twitterUrl: String
   type: GuildType_enum
-  website_url: String
+  websiteUrl: String
 }
 
 """aggregate max on columns"""
 type guild_max_fields {
   description: String
-  discord_id: String
-  discord_invite_url: String
-  github_url: String
+  discordId: String
+  discordInviteUrl: String
+  githubUrl: String
   guildname: String
   id: uuid
-  join_button_url: String
+  joinButtonUrl: String
   logo: String
   name: String
-  twitter_url: String
-  website_url: String
+  twitterUrl: String
+  websiteUrl: String
 }
 
 """
@@ -1698,16 +1698,16 @@ order by max() on columns of table "guild"
 """
 input guild_max_order_by {
   description: order_by
-  discord_id: order_by
-  discord_invite_url: order_by
-  github_url: order_by
+  discordId: order_by
+  discordInviteUrl: order_by
+  githubUrl: order_by
   guildname: order_by
   id: order_by
-  join_button_url: order_by
+  joinButtonUrl: order_by
   logo: order_by
   name: order_by
-  twitter_url: order_by
-  website_url: order_by
+  twitterUrl: order_by
+  websiteUrl: order_by
 }
 
 """
@@ -1718,19 +1718,19 @@ columns and relationships of "guild_metadata"
 
 """
 type guild_metadata {
-  creator_id: uuid
-
-  """Remote relationship field"""
-  discordRoles: [DiscordRole!]!
-  discord_id: String!
-  discord_metadata(
+  creatorId: uuid
+  discordId: String!
+  discordMetadata(
     """JSON select path"""
     path: String
   ): jsonb
 
+  """Remote relationship field"""
+  discordRoles: [DiscordRole!]!
+
   """An object relationship"""
   guild: guild!
-  guild_id: uuid!
+  guildId: uuid!
 
   """An object relationship"""
   player: player
@@ -1764,7 +1764,7 @@ input guild_metadata_aggregate_order_by {
 
 """append existing jsonb value of filtered columns with new jsonb value"""
 input guild_metadata_append_input {
-  discord_metadata: jsonb
+  discordMetadata: jsonb
 }
 
 """
@@ -1782,11 +1782,11 @@ input guild_metadata_bool_exp {
   _and: [guild_metadata_bool_exp]
   _not: guild_metadata_bool_exp
   _or: [guild_metadata_bool_exp]
-  creator_id: uuid_comparison_exp
-  discord_id: String_comparison_exp
-  discord_metadata: jsonb_comparison_exp
+  creatorId: uuid_comparison_exp
+  discordId: String_comparison_exp
+  discordMetadata: jsonb_comparison_exp
   guild: guild_bool_exp
-  guild_id: uuid_comparison_exp
+  guildId: uuid_comparison_exp
   player: player_bool_exp
 }
 
@@ -1802,7 +1802,7 @@ enum guild_metadata_constraint {
 delete the field or element with specified path (for JSON arrays, negative integers count from the end)
 """
 input guild_metadata_delete_at_path_input {
-  discord_metadata: [String]
+  discordMetadata: [String]
 }
 
 """
@@ -1810,58 +1810,58 @@ delete the array element with specified index (negative integers count from the
 end). throws an error if top level container is not an array
 """
 input guild_metadata_delete_elem_input {
-  discord_metadata: Int
+  discordMetadata: Int
 }
 
 """
 delete key/value pair or string element. key/value pairs are matched based on their key value
 """
 input guild_metadata_delete_key_input {
-  discord_metadata: String
+  discordMetadata: String
 }
 
 """
 input type for inserting data into table "guild_metadata"
 """
 input guild_metadata_insert_input {
-  creator_id: uuid
-  discord_id: String
-  discord_metadata: jsonb
+  creatorId: uuid
+  discordId: String
+  discordMetadata: jsonb
   guild: guild_obj_rel_insert_input
-  guild_id: uuid
+  guildId: uuid
   player: player_obj_rel_insert_input
 }
 
 """aggregate max on columns"""
 type guild_metadata_max_fields {
-  creator_id: uuid
-  discord_id: String
-  guild_id: uuid
+  creatorId: uuid
+  discordId: String
+  guildId: uuid
 }
 
 """
 order by max() on columns of table "guild_metadata"
 """
 input guild_metadata_max_order_by {
-  creator_id: order_by
-  discord_id: order_by
-  guild_id: order_by
+  creatorId: order_by
+  discordId: order_by
+  guildId: order_by
 }
 
 """aggregate min on columns"""
 type guild_metadata_min_fields {
-  creator_id: uuid
-  discord_id: String
-  guild_id: uuid
+  creatorId: uuid
+  discordId: String
+  guildId: uuid
 }
 
 """
 order by min() on columns of table "guild_metadata"
 """
 input guild_metadata_min_order_by {
-  creator_id: order_by
-  discord_id: order_by
-  guild_id: order_by
+  creatorId: order_by
+  discordId: order_by
+  guildId: order_by
 }
 
 """
@@ -1896,11 +1896,11 @@ input guild_metadata_on_conflict {
 ordering options when selecting data from "guild_metadata"
 """
 input guild_metadata_order_by {
-  creator_id: order_by
-  discord_id: order_by
-  discord_metadata: order_by
+  creatorId: order_by
+  discordId: order_by
+  discordMetadata: order_by
   guild: guild_order_by
-  guild_id: order_by
+  guildId: order_by
   player: player_order_by
 }
 
@@ -1908,12 +1908,12 @@ input guild_metadata_order_by {
 primary key columns input for table: "guild_metadata"
 """
 input guild_metadata_pk_columns_input {
-  guild_id: uuid!
+  guildId: uuid!
 }
 
 """prepend existing jsonb value of filtered columns with new jsonb value"""
 input guild_metadata_prepend_input {
-  discord_metadata: jsonb
+  discordMetadata: jsonb
 }
 
 """
@@ -1921,26 +1921,26 @@ select columns of table "guild_metadata"
 """
 enum guild_metadata_select_column {
   """column name"""
-  creator_id
+  creatorId
 
   """column name"""
-  discord_id
+  discordId
 
   """column name"""
-  discord_metadata
+  discordMetadata
 
   """column name"""
-  guild_id
+  guildId
 }
 
 """
 input type for updating data in table "guild_metadata"
 """
 input guild_metadata_set_input {
-  creator_id: uuid
-  discord_id: String
-  discord_metadata: jsonb
-  guild_id: uuid
+  creatorId: uuid
+  discordId: String
+  discordMetadata: jsonb
+  guildId: uuid
 }
 
 """
@@ -1948,31 +1948,31 @@ update columns of table "guild_metadata"
 """
 enum guild_metadata_update_column {
   """column name"""
-  creator_id
+  creatorId
 
   """column name"""
-  discord_id
+  discordId
 
   """column name"""
-  discord_metadata
+  discordMetadata
 
   """column name"""
-  guild_id
+  guildId
 }
 
 """aggregate min on columns"""
 type guild_min_fields {
   description: String
-  discord_id: String
-  discord_invite_url: String
-  github_url: String
+  discordId: String
+  discordInviteUrl: String
+  githubUrl: String
   guildname: String
   id: uuid
-  join_button_url: String
+  joinButtonUrl: String
   logo: String
   name: String
-  twitter_url: String
-  website_url: String
+  twitterUrl: String
+  websiteUrl: String
 }
 
 """
@@ -1980,16 +1980,16 @@ order by min() on columns of table "guild"
 """
 input guild_min_order_by {
   description: order_by
-  discord_id: order_by
-  discord_invite_url: order_by
-  github_url: order_by
+  discordId: order_by
+  discordInviteUrl: order_by
+  githubUrl: order_by
   guildname: order_by
   id: order_by
-  join_button_url: order_by
+  joinButtonUrl: order_by
   logo: order_by
   name: order_by
-  twitter_url: order_by
-  website_url: order_by
+  twitterUrl: order_by
+  websiteUrl: order_by
 }
 
 """
@@ -2027,23 +2027,23 @@ input guild_order_by {
   GuildType: GuildType_order_by
   daos_aggregate: dao_aggregate_order_by
   description: order_by
-  discord_id: order_by
-  discord_invite_url: order_by
-  github_url: order_by
+  discordId: order_by
+  discordInviteUrl: order_by
+  githubUrl: order_by
   guild_players_aggregate: guild_player_aggregate_order_by
   guildname: order_by
   id: order_by
-  join_button_url: order_by
+  joinButtonUrl: order_by
   logo: order_by
-  membership_through_discord: order_by
+  membershipThroughDiscord: order_by
   metadata: guild_metadata_order_by
   name: order_by
   position: order_by
   quests_aggregate: quest_aggregate_order_by
   status: order_by
-  twitter_url: order_by
+  twitterUrl: order_by
   type: order_by
-  website_url: order_by
+  websiteUrl: order_by
 }
 
 """
@@ -2065,8 +2065,8 @@ type guild_player {
 
   """Remote relationship field"""
   discordRoles: [DiscordRole!]!
-  guild_id: uuid!
-  player_id: uuid!
+  guildId: uuid!
+  playerId: uuid!
 }
 
 """
@@ -2112,8 +2112,8 @@ input guild_player_bool_exp {
   _and: [guild_player_bool_exp]
   _not: guild_player_bool_exp
   _or: [guild_player_bool_exp]
-  guild_id: uuid_comparison_exp
-  player_id: uuid_comparison_exp
+  guildId: uuid_comparison_exp
+  playerId: uuid_comparison_exp
 }
 
 """
@@ -2130,36 +2130,36 @@ input type for inserting data into table "guild_player"
 input guild_player_insert_input {
   Guild: guild_obj_rel_insert_input
   Player: player_obj_rel_insert_input
-  guild_id: uuid
-  player_id: uuid
+  guildId: uuid
+  playerId: uuid
 }
 
 """aggregate max on columns"""
 type guild_player_max_fields {
-  guild_id: uuid
-  player_id: uuid
+  guildId: uuid
+  playerId: uuid
 }
 
 """
 order by max() on columns of table "guild_player"
 """
 input guild_player_max_order_by {
-  guild_id: order_by
-  player_id: order_by
+  guildId: order_by
+  playerId: order_by
 }
 
 """aggregate min on columns"""
 type guild_player_min_fields {
-  guild_id: uuid
-  player_id: uuid
+  guildId: uuid
+  playerId: uuid
 }
 
 """
 order by min() on columns of table "guild_player"
 """
 input guild_player_min_order_by {
-  guild_id: order_by
-  player_id: order_by
+  guildId: order_by
+  playerId: order_by
 }
 
 """
@@ -2196,16 +2196,16 @@ ordering options when selecting data from "guild_player"
 input guild_player_order_by {
   Guild: guild_order_by
   Player: player_order_by
-  guild_id: order_by
-  player_id: order_by
+  guildId: order_by
+  playerId: order_by
 }
 
 """
 primary key columns input for table: "guild_player"
 """
 input guild_player_pk_columns_input {
-  guild_id: uuid!
-  player_id: uuid!
+  guildId: uuid!
+  playerId: uuid!
 }
 
 """
@@ -2213,18 +2213,18 @@ select columns of table "guild_player"
 """
 enum guild_player_select_column {
   """column name"""
-  guild_id
+  guildId
 
   """column name"""
-  player_id
+  playerId
 }
 
 """
 input type for updating data in table "guild_player"
 """
 input guild_player_set_input {
-  guild_id: uuid
-  player_id: uuid
+  guildId: uuid
+  playerId: uuid
 }
 
 """
@@ -2232,10 +2232,10 @@ update columns of table "guild_player"
 """
 enum guild_player_update_column {
   """column name"""
-  guild_id
+  guildId
 
   """column name"""
-  player_id
+  playerId
 }
 
 """
@@ -2246,13 +2246,13 @@ enum guild_select_column {
   description
 
   """column name"""
-  discord_id
+  discordId
 
   """column name"""
-  discord_invite_url
+  discordInviteUrl
 
   """column name"""
-  github_url
+  githubUrl
 
   """column name"""
   guildname
@@ -2261,13 +2261,13 @@ enum guild_select_column {
   id
 
   """column name"""
-  join_button_url
+  joinButtonUrl
 
   """column name"""
   logo
 
   """column name"""
-  membership_through_discord
+  membershipThroughDiscord
 
   """column name"""
   name
@@ -2279,13 +2279,13 @@ enum guild_select_column {
   status
 
   """column name"""
-  twitter_url
+  twitterUrl
 
   """column name"""
   type
 
   """column name"""
-  website_url
+  websiteUrl
 }
 
 """
@@ -2293,20 +2293,20 @@ input type for updating data in table "guild"
 """
 input guild_set_input {
   description: String
-  discord_id: String
-  discord_invite_url: String
-  github_url: String
+  discordId: String
+  discordInviteUrl: String
+  githubUrl: String
   guildname: String
   id: uuid
-  join_button_url: String
+  joinButtonUrl: String
   logo: String
-  membership_through_discord: Boolean
+  membershipThroughDiscord: Boolean
   name: String
   position: GuildPosition_enum
   status: GuildStatus_enum
-  twitter_url: String
+  twitterUrl: String
   type: GuildType_enum
-  website_url: String
+  websiteUrl: String
 }
 
 """
@@ -2317,13 +2317,13 @@ enum guild_update_column {
   description
 
   """column name"""
-  discord_id
+  discordId
 
   """column name"""
-  discord_invite_url
+  discordInviteUrl
 
   """column name"""
-  github_url
+  githubUrl
 
   """column name"""
   guildname
@@ -2332,13 +2332,13 @@ enum guild_update_column {
   id
 
   """column name"""
-  join_button_url
+  joinButtonUrl
 
   """column name"""
   logo
 
   """column name"""
-  membership_through_discord
+  membershipThroughDiscord
 
   """column name"""
   name
@@ -2350,38 +2350,38 @@ enum guild_update_column {
   status
 
   """column name"""
-  twitter_url
+  twitterUrl
 
   """column name"""
   type
 
   """column name"""
-  website_url
+  websiteUrl
 }
 
-input GuildDao {
+input GuildDaoInput {
   contractAddress: String!
   label: String
   network: String!
   url: String
 }
 
-input GuildInfo {
-  daos: [GuildDao!]
+input GuildInfoInput {
+  daos: [GuildDaoInput!]
   description: String
   discordAdminRoles: [String]!
-  discordInviteURL: String
+  discordInviteUrl: String
   discordMembershipRoles: [String]!
-  githubURL: String
+  githubUrl: String
   guildname: String!
-  joinURL: String
-  logoURL: String
+  joinUrl: String
+  logoUrl: String
   membershipThroughDiscord: Boolean
   name: String!
-  twitterURL: String
+  twitterUrl: String
   type: GuildType_ActionEnum!
   uuid: String!
-  websiteURL: String
+  websiteUrl: String
 }
 
 """
@@ -3364,7 +3364,7 @@ type mutation_root {
   """
   delete single row from the table: "guild_metadata"
   """
-  delete_guild_metadata_by_pk(guild_id: uuid!): guild_metadata
+  delete_guild_metadata_by_pk(guildId: uuid!): guild_metadata
 
   """
   delete data from the table: "guild_player"
@@ -3377,7 +3377,7 @@ type mutation_root {
   """
   delete single row from the table: "guild_player"
   """
-  delete_guild_player_by_pk(guild_id: uuid!, player_id: uuid!): guild_player
+  delete_guild_player_by_pk(guildId: uuid!, playerId: uuid!): guild_player
 
   """
   delete data from the table: "player"
@@ -4101,7 +4101,7 @@ type mutation_root {
   """
   perform the action: "saveGuildInformation"
   """
-  saveGuildInformation(guildInformation: GuildInfo!): SaveGuildResponse
+  saveGuildInformation(guildInformation: GuildInfoInput!): SaveGuildResponse
 
   """
   perform the action: "updateExpiredIDXProfiles"
@@ -7977,7 +7977,7 @@ type query_root {
   ): guild_metadata_aggregate!
 
   """fetch data from the table: "guild_metadata" using primary key columns"""
-  guild_metadata_by_pk(guild_id: uuid!): guild_metadata
+  guild_metadata_by_pk(guildId: uuid!): guild_metadata
 
   """
   fetch data from the table: "guild_player"
@@ -8020,7 +8020,7 @@ type query_root {
   ): guild_player_aggregate!
 
   """fetch data from the table: "guild_player" using primary key columns"""
-  guild_player_by_pk(guild_id: uuid!, player_id: uuid!): guild_player
+  guild_player_by_pk(guildId: uuid!, playerId: uuid!): guild_player
 
   """
   fetch data from the table: "me"
@@ -11594,7 +11594,7 @@ type subscription_root {
   ): guild_metadata_aggregate!
 
   """fetch data from the table: "guild_metadata" using primary key columns"""
-  guild_metadata_by_pk(guild_id: uuid!): guild_metadata
+  guild_metadata_by_pk(guildId: uuid!): guild_metadata
 
   """
   fetch data from the table: "guild_player"
@@ -11637,7 +11637,7 @@ type subscription_root {
   ): guild_player_aggregate!
 
   """fetch data from the table: "guild_player" using primary key columns"""
-  guild_player_by_pk(guild_id: uuid!, player_id: uuid!): guild_player
+  guild_player_by_pk(guildId: uuid!, playerId: uuid!): guild_player
 
   """
   fetch data from the table: "me"


### PR DESCRIPTION
## Overview

There are a few outstanding issues with our DAO / guild / player relationships, with the main end-goal being having a new set of tables (dao and dao_players) that we can use as a cache to avoid the very expensive daohaus queries we're currently making.  My plan for this is:

1. Create those two new tables, including a guild_id in the dao table so that guilds can associate one or more daos / multisigs / treasury addresses. Also add the relevant fields currently being returned from daohaus 
2. Refactor the current guild / moloch_address persistence code to instead persist 1 or more daos. This includes updating the guild create / edit form 
3. Add any of a guild's inputted DAO data to the guild page
4. Remove the current daohaus remote schema relationship for a player in favor of a more generic action to be called to update the cached data in the new dao tables
5. Implement the cache update using the current IDX player caching logic as a model

This PR tackles 1 - 3, 4/5 will be addressed in later PRs.

Closes #1142

## Follow-up Items

- Add another page `/guild/[guildname]/edit` rather than just linking to the `/join/guild` page. It works, but the UI is not totally accurate 