### PR TITLE
fix: wrong params order of personal_sign

### DIFF
--- a/packages/utils/src/ethereumHelper.ts
+++ b/packages/utils/src/ethereumHelper.ts
@@ -9,7 +9,7 @@ export async function getSignature(
   const address = await signer.getAddress();
   if (!ethereum.request) throw new Error('No `request` On Ethereum Provider');
 
-  let params = [msg, address.toLowerCase()];
+  let params = [msg, address];
   const signature = await ethereum.request({
     method: 'personal_sign',
     params,

--- a/packages/utils/src/ethereumHelper.ts
+++ b/packages/utils/src/ethereumHelper.ts
@@ -10,9 +10,6 @@ export async function getSignature(
   if (!ethereum.request) throw new Error('No `request` On Ethereum Provider');
 
   let params = [msg, address.toLowerCase()];
-  if (ethereum.isMetaMask) {
-    params = [params[1], params[0]];
-  }
   const signature = await ethereum.request({
     method: 'personal_sign',
     params,

--- a/packages/utils/src/ethereumHelper.ts
+++ b/packages/utils/src/ethereumHelper.ts
@@ -9,7 +9,7 @@ export async function getSignature(
   const address = await signer.getAddress();
   if (!ethereum.request) throw new Error('No `request` On Ethereum Provider');
 
-  let params = [msg, address];
+  const params = [msg, address];
   const signature = await ethereum.request({
     method: 'personal_sign',
     params,


### PR DESCRIPTION
## Overview

**What features/fixes does this PR include?**
**Please provide the GitHub issue number**

Closes #945

## Follow up Improvement Ideas

- [x] please list any improvement/ideas

## Implementation

**Describe technical (nontrivial / non-obvious) parts of your code**

as https://web3js.readthedocs.io/en/v1.2.11/web3-eth-personal.html#sign said, the second param of personal_sign should be address, not sure why switched in your code, let me know if there is any concern

**Side effects**
No

## Assets

[Include screenshots/videos if it makes reviewing easier.]
