### PR TITLE
Fix two major UI issues

### DIFF
--- a/packages/web/pages/guild/[guildname].tsx
+++ b/packages/web/pages/guild/[guildname].tsx
@@ -39,10 +39,11 @@ const GuildPage: React.FC<Props> = ({ guild }) => {
 
   const canEdit = useMemo(
     () =>
+      user != null &&
       user?.id ===
-      getGuildsResult?.data?.guild_metadata.some(
-        (gm) => gm.guildId === guild?.id,
-      ),
+        getGuildsResult?.data?.guild_metadata.some(
+          (gm) => gm.guildId === guild?.id,
+        ),
     [user, getGuildsResult, guild],
   );
 

--- a/packages/web/pages/index.tsx
+++ b/packages/web/pages/index.tsx
@@ -21,7 +21,13 @@ export const getStaticProps = async () => ({
 });
 
 const ArrowUp: React.FC = () => (
-  <svg strokeWidth={0} viewBox="0 0 16 16" focusable="false">
+  <svg
+    strokeWidth={0}
+    viewBox="0 0 16 16"
+    focusable="false"
+    width="16"
+    height="16"
+  >
     <defs>
       <linearGradient id="grad1" x1="0%" y1="0%" x2="100%" y2="0%">
         <stop offset="0%" style={{ stopColor: '#FF61E6', stopOpacity: 1 }} />


### PR DESCRIPTION
## Overview

Fixes two major issues:
- the edit button appeared on the guild page if you were not logged in. You can't actually view any non-public guild info (or update anything), but it's awkward to say the least.
- the landing page had a major visual bug on Firefox.

## Follow up Improvement Ideas

- The guild edit icon doesn't actually render if you are the guild owner.  After a couple hours of debugging I tracked it down to the graphql client it is using. Its requests are not even authenticated for some reason.

## Assets

<img width="729" alt="Screen Shot 2022-03-08 at 2 23 07 PM" src="https://user-images.githubusercontent.com/1402582/158048646-30541f1e-fb33-47be-bb2a-ff3fc53bf5e7.png">

