### PR TITLE
Reverting the asynchronous flag on cache invalidation to reenable profile loading

### DIFF
--- a/hasura/metadata/actions.yaml
+++ b/hasura/metadata/actions.yaml
@@ -34,7 +34,7 @@ actions:
     handler: '{{ACTION_BASE_ENDPOINT}}/idxCache/checkExpired'
 - name: updateIDXProfile
   definition:
-    kind: synchronous
+    kind: asynchronous
     handler: '{{ACTION_BASE_ENDPOINT}}/idxCache/updateSingle'
     forward_client_headers: true
   permissions:

--- a/packages/web/components/Player/PlayerTile.tsx
+++ b/packages/web/components/Player/PlayerTile.tsx
@@ -104,7 +104,7 @@ export const PlayerTile: React.FC<Props> = ({
                 {showSeasonalXP && (
                   <WrapItem>
                     <MetaTag size="md">
-                      SEASON Ⅴ XP:{' '}
+                      SEASON Ⅵ XP:{' '}
                       {Math.floor(player.seasonXP).toLocaleString()}
                     </MetaTag>
                   </WrapItem>


### PR DESCRIPTION
## Overview

@alalonde, perhaps inadvertently, changed the type of request being made for cache invalidation from `asynchronous` to `synchronous` [a few weeks ago](//github.com/MetaFam/TheGame/commit/2c32e2702fc9601fc2d47058900cc1648620d7c8). Since the return type from an asynchronous call is a UUID while synchronous calls have to have a selection of subfields, cache invalidation requests have been failing since this was changed.

## Implementation

I changed one value in the metadata schema via the Hasura console. It took me about 45 minutes to figure out it had nothing to do with GraphQL and notice the toggle was changed.

To beef up this puny PR, I also updated the Season # to Ⅵ.