### PR TITLE
Fix database seeding of PR backend instances

### DIFF
--- a/.github/workflows/gcp-deploy.yaml
+++ b/.github/workflows/gcp-deploy.yaml
@@ -284,7 +284,7 @@ jobs:
             --region ${{needs.env.outputs.CLOUDRUN_REGION}} \
             --port ${{needs.env.outputs.BACKEND_PORT}} \
             --cpu 1 \
-            --memory 512Mi \
+            --memory 768Mi \
             --ingress all \
             --allow-unauthenticated \
             --max-instances 1 \


### PR DESCRIPTION
The `seed-db` task as part a PR deployment has not been working for some time.

This task calls the `migrateSourceCredAccounts` action, which itself loads the entire SourceCred ledger into memory.  This has been failing on these backend instances because they are "only" provisioned with 512MB of memory. I tested bumping one of the instances up to 768M (PR 1250) and it worked, hence this PR.