### PR TITLE
Support relative imports in backend package

### DIFF
--- a/docker/backend/Dockerfile
+++ b/docker/backend/Dockerfile
@@ -51,7 +51,9 @@ COPY --from=build /usr/src/app/package.json ./package.json
 COPY --from=build /usr/src/app/node_modules ./node_modules
 
 COPY --from=build /usr/src/app/packages/backend/package.json ./packages/backend/package.json
+COPY --from=build /usr/src/app/packages/backend/tsconfig-paths-bootstrap.js ./packages/backend/tsconfig-paths-bootstrap.js
 COPY --from=build /usr/src/app/packages/backend/dist ./packages/backend/dist
+COPY --from=build /usr/src/app/packages/backend/node_modules ./packages/backend/node_modules
 
 COPY --from=build /usr/src/app/packages/utils/package.json ./packages/utils/package.json
 COPY --from=build /usr/src/app/packages/utils/dist ./packages/utils/dist

--- a/packages/backend/package.json
+++ b/packages/backend/package.json
@@ -8,7 +8,7 @@
     "start": "node ./dist/index.js",
     "build": "yarn generate && tsc -b",
     "dev": "concurrently \"yarn dev-ts\" \"yarn generate --watch\"",
-    "dev-ts": "ts-node-dev --exit-child --inspect=0.0.0.0:4322 --respawn -- src/index.ts",
+    "dev-ts": "ts-node-dev --exit-child --respawn -r tsconfig-paths/register -- src/index.ts",
     "typecheck": "yarn build",
     "precommit": "yarn lint-staged",
     "generate": "graphql-codegen --config=codegen.yml",
@@ -54,6 +54,7 @@
     "@types/body-parser": "1.19.2",
     "@types/cors": "2.8.12",
     "nock": "13.2.4",
-    "ts-node-dev": "1.1.8"
+    "ts-node-dev": "1.1.8",
+    "tsconfig-paths": "^4.0.0"
   }
 }

--- a/packages/backend/package.json
+++ b/packages/backend/package.json
@@ -5,10 +5,10 @@
   "description": "",
   "main": "dist/index.js",
   "scripts": {
-    "start": "node ./dist/index.js",
+    "start": "node -r ./tsconfig-paths-bootstrap.js ./dist/index.js",
     "build": "yarn generate && tsc -b",
     "dev": "concurrently \"yarn dev-ts\" \"yarn generate --watch\"",
-    "dev-ts": "ts-node-dev --exit-child --respawn -r tsconfig-paths/register -- src/index.ts",
+    "dev-ts": "ts-node-dev --exit-child --respawn -r tsconfig-paths/register  --inspect=0.0.0.0:4322 -- src/index.ts",
     "typecheck": "yarn build",
     "precommit": "yarn lint-staged",
     "generate": "graphql-codegen --config=codegen.yml",
@@ -46,6 +46,7 @@
     "node-fetch": "3.2.1",
     "reflect-metadata": "0.1.13",
     "sourcecred": "0.11.0",
+    "tsconfig-paths": "^4.0.0",
     "uuid": "8.3.2",
     "web3.storage": "3.5.6"
   },
@@ -54,7 +55,6 @@
     "@types/body-parser": "1.19.2",
     "@types/cors": "2.8.12",
     "nock": "13.2.4",
-    "ts-node-dev": "1.1.8",
-    "tsconfig-paths": "^4.0.0"
+    "ts-node-dev": "1.1.8"
   }
 }

--- a/packages/backend/src/handlers/remote-schemas/resolvers/discord/resolver.ts
+++ b/packages/backend/src/handlers/remote-schemas/resolvers/discord/resolver.ts
@@ -1,62 +1,59 @@
 import { createDiscordClient } from '@metafam/discord-bot';
 import { Role } from 'discord.js';
+import { client } from 'lib/hasuraClient';
 
-import { client } from '../../../../lib/hasuraClient';
 import { QueryResolvers } from '../../autogen/types';
 
-export const getGuildDiscordRoles: QueryResolvers['getGuildDiscordRoles'] = async (
-  _,
-  { guildDiscordId },
-) => {
-  if (!guildDiscordId) return [];
+export const getGuildDiscordRoles: QueryResolvers['getGuildDiscordRoles'] =
+  async (_, { guildDiscordId }) => {
+    if (!guildDiscordId) return [];
 
-  const discordClient = await createDiscordClient();
-  const discordGuild = await discordClient.guilds.fetch(guildDiscordId);
+    const discordClient = await createDiscordClient();
+    const discordGuild = await discordClient.guilds.fetch(guildDiscordId);
 
-  if (discordGuild != null) {
-    await discordGuild.roles.fetch();
-    return discordGuild.roles.cache.map((role: Role) => ({
-      id: role.id,
-      position: role.position,
-      name: role.name,
-    }));
-  }
+    if (discordGuild != null) {
+      await discordGuild.roles.fetch();
+      return discordGuild.roles.cache.map((role: Role) => ({
+        id: role.id,
+        position: role.position,
+        name: role.name,
+      }));
+    }
 
-  return [];
-};
+    return [];
+  };
 
-export const getDiscordServerMemberRoles: QueryResolvers['getDiscordServerMemberRoles'] = async (
-  _,
-  { guildId, playerId },
-) => {
-  const getGuildPlayerResponse = await client.GetGuildPlayerDiscordIds({
-    guildId,
-    playerId,
-  });
-  const guildDiscordId = getGuildPlayerResponse.guild_player[0].Guild.discordId;
-  const playerDiscordId =
-    getGuildPlayerResponse.guild_player[0].Player.discordId;
+export const getDiscordServerMemberRoles: QueryResolvers['getDiscordServerMemberRoles'] =
+  async (_, { guildId, playerId }) => {
+    const getGuildPlayerResponse = await client.GetGuildPlayerDiscordIds({
+      guildId,
+      playerId,
+    });
+    const guildDiscordId =
+      getGuildPlayerResponse.guild_player[0].Guild.discordId;
+    const playerDiscordId =
+      getGuildPlayerResponse.guild_player[0].Player.discordId;
 
-  if (guildDiscordId == null || playerDiscordId == null) return [];
+    if (guildDiscordId == null || playerDiscordId == null) return [];
 
-  const discordClient = await createDiscordClient();
-  const discordGuild = await discordClient.guilds.fetch(guildDiscordId);
+    const discordClient = await createDiscordClient();
+    const discordGuild = await discordClient.guilds.fetch(guildDiscordId);
 
-  if (discordGuild != null) {
-    await discordGuild.members.fetch(playerDiscordId);
-    await discordGuild.roles.fetch();
-    const member = discordGuild.members.cache.get(playerDiscordId);
+    if (discordGuild != null) {
+      await discordGuild.members.fetch(playerDiscordId);
+      await discordGuild.roles.fetch();
+      const member = discordGuild.members.cache.get(playerDiscordId);
 
-    if (member == null) return [];
+      if (member == null) return [];
 
-    // these are returned in descending order by position
-    // (meaning, most significant role is first)
-    return member.roles.cache.map((role: Role) => ({
-      id: role.id,
-      position: role.position,
-      name: role.name,
-    }));
-  }
+      // these are returned in descending order by position
+      // (meaning, most significant role is first)
+      return member.roles.cache.map((role: Role) => ({
+        id: role.id,
+        position: role.position,
+        name: role.name,
+      }));
+    }
 
-  return [];
-};
+    return [];
+  };

--- a/packages/backend/tsconfig-paths-bootstrap.js
+++ b/packages/backend/tsconfig-paths-bootstrap.js
@@ -1,0 +1,15 @@
+/* 
+This is a custom configuration for tsconfig-paths to be able to "fix" 
+relative paths at runtime (in node.js) in the Docker container.  tsconfig-paths 
+"just works" for local dev, but this extra configuration is necessary when 
+running in Docker since at that point we're just running the transpiled 
+javascript in the dist directory.
+*/
+
+// eslint-disable-next-line @typescript-eslint/no-var-requires
+const tsConfigPaths = require('tsconfig-paths');
+
+tsConfigPaths.register({
+  baseUrl: 'dist',
+  paths: {},
+});

--- a/packages/backend/tsconfig.json
+++ b/packages/backend/tsconfig.json
@@ -8,6 +8,7 @@
     "target": "ES2021",
     "outDir": "dist",
     "rootDir": "src",
+    "baseUrl": "src",
     "composite": true,
     "tsBuildInfoFile": "dist/.tsbuildinfo"
   },

--- a/packages/backend/tsconfig.json
+++ b/packages/backend/tsconfig.json
@@ -12,6 +12,6 @@
     "tsBuildInfoFile": "dist/.tsbuildinfo"
   },
   "references": [{ "path": "../utils" }, { "path": "../discord-bot" }],
-  "include": ["src", "src/**/*.json"],
+  "include": ["src/**/*.ts", "src/**/*.json"],
   "exclude": ["./tests"]
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -16265,6 +16265,11 @@ json5@^1.0.1:
   dependencies:
     minimist "^1.2.0"
 
+json5@^2.2.1:
+  version "2.2.1"
+  resolved "https://registry.yarnpkg.com/json5/-/json5-2.2.1.tgz#655d50ed1e6f95ad1a3caababd2b0efda10b395c"
+  integrity sha512-1hqLFMSrGHRHxav9q9gNjJ5EXznIxGVO09xQRrwplcS8qs28pZ8s8hupZAmqDwZUmVZ2Qb2jnyPOWcDH8m8dlA==
+
 jsonexport@^2.4.1:
   version "2.5.2"
   resolved "https://registry.yarnpkg.com/jsonexport/-/jsonexport-2.5.2.tgz#fafbcdb2cb8e12d0a2a92cda6e0634c8d48005ac"
@@ -17541,6 +17546,11 @@ minimist@^1.1.1, minimist@^1.1.3, minimist@^1.2.0, minimist@^1.2.3, minimist@^1.
   version "1.2.5"
   resolved "https://registry.yarnpkg.com/minimist/-/minimist-1.2.5.tgz#67d66014b66a6a8aaa0c083c5fd58df4e4e97602"
   integrity sha512-FM9nNUYrRBAELZQT3xeZQ7fmMOBg6nWNmJKTcgsJeaLstP/UODVpGsr5OhXhhXg6f+qtJ8uiZ+PUxkDWcgIXLw==
+
+minimist@^1.2.6:
+  version "1.2.6"
+  resolved "https://registry.yarnpkg.com/minimist/-/minimist-1.2.6.tgz#8637a5b759ea0d6e98702cfb3a9283323c93af44"
+  integrity sha512-Jsjnk4bw3YJqYzbdyBiNsPWHPfO++UGG749Cxs6peCu5Xg4nrena6OVxOYxrQTqww0Jmwt+Ref8rggumkTLz9Q==
 
 minipass-collect@^1.0.2:
   version "1.0.2"
@@ -22945,6 +22955,15 @@ tsconfig-paths@^3.9.0:
     "@types/json5" "^0.0.29"
     json5 "^1.0.1"
     minimist "^1.2.0"
+    strip-bom "^3.0.0"
+
+tsconfig-paths@^4.0.0:
+  version "4.0.0"
+  resolved "https://registry.yarnpkg.com/tsconfig-paths/-/tsconfig-paths-4.0.0.tgz#1082f5d99fd127b72397eef4809e4dd06d229b64"
+  integrity sha512-SLBg2GBKlR6bVtMgJJlud/o3waplKtL7skmLkExomIiaAtLGtVsoXIqP3SYdjbcH9lq/KVv7pMZeCBpLYOit6Q==
+  dependencies:
+    json5 "^2.2.1"
+    minimist "^1.2.6"
     strip-bom "^3.0.0"
 
 tsconfig@^7.0.0:


### PR DESCRIPTION
## Overview

**What features/fixes does this PR include?**

This allows relative imports in the backend project:

```
// Before: yuck
import { client } from '../../../../../../lib/hasuraClient';
```

```
// After: yes
import { client } from 'lib/hasuraClient';
```

As the codebase grows, importing code from e.g. seven subdirectories up the tree gets more and more unwieldy. 

## Implementation

Getting this to work with tsc was trivially easy, just adding `"baseUrl": "src"` to the `tsconfig.json`.

Getting to work with ts-node and then node was much more difficult, requiring [this package](https://github.com/dividab/tsconfig-paths) with a custom configuration when run with `node` in the docker container.
