### PR TITLE
Fix XP sync for players with multiple linked eth addresses in SC

### DIFF
--- a/packages/utils/src/sourceCredHelpers.ts
+++ b/packages/utils/src/sourceCredHelpers.ts
@@ -1,19 +1,17 @@
-import { ethers } from 'ethers';
+import { utils } from 'ethers';
 import { SCIdentity, sourcecred as sc } from 'sourcecred';
 
 export const getLatestEthAddress = (identity: SCIdentity): string | null => {
   const ethAddresses = identity.aliases.filter((alias) => {
     const parts = sc.core.graph.NodeAddress.toParts(alias.address);
-    return (
-      parts.indexOf('ethereum') > 0 && ethers.utils.isAddress(alias.description)
-    );
+    return parts.indexOf('ethereum') > 0 && utils.isAddress(alias.description);
   });
   if (ethAddresses.length > 0) {
     // this assumes that the fetched data is in chronological order, which should
     // be the case for the SC Ledger
     const latestAddress = ethAddresses.pop();
     if (latestAddress != null) {
-      return latestAddress?.description.toLowerCase();
+      return latestAddress.description.toLowerCase();
     }
   }
 

--- a/packages/utils/src/sourceCredHelpers.ts
+++ b/packages/utils/src/sourceCredHelpers.ts
@@ -2,13 +2,19 @@ import { ethers } from 'ethers';
 import { SCIdentity, sourcecred as sc } from 'sourcecred';
 
 export const getLatestEthAddress = (identity: SCIdentity): string | null => {
-  const ethAddress = identity.aliases.find((alias) => {
+  const ethAddresses = identity.aliases.filter((alias) => {
     const parts = sc.core.graph.NodeAddress.toParts(alias.address);
-    return parts.indexOf('ethereum') > 0;
-  })?.description;
-
-  if (ethAddress && ethers.utils.isAddress(ethAddress)) {
-    return ethAddress.toLowerCase();
+    return (
+      parts.indexOf('ethereum') > 0 && ethers.utils.isAddress(alias.description)
+    );
+  });
+  if (ethAddresses.length > 0) {
+    // this assumes that the fetched data is in chronological order, which should
+    // be the case for the SC Ledger
+    const latestAddress = ethAddresses.pop();
+    if (latestAddress != null) {
+      return latestAddress?.description.toLowerCase();
+    }
   }
 
   return null;

--- a/packages/web/lib/hooks/useUserXP.ts
+++ b/packages/web/lib/hooks/useUserXP.ts
@@ -1,5 +1,5 @@
 import { Constants } from '@metafam/utils';
-import { ethers } from 'ethers';
+import { utils } from 'ethers';
 import { useEffect, useState } from 'react';
 import { SCAccount, SCAccountsData } from 'sourcecred';
 
@@ -15,7 +15,7 @@ interface XPProps {
 export const useUserXP = (userAddress: string): XPProps | null => {
   const [xpDataObj, setXPDataObj] = useState<XPProps | null>(null);
   useEffect(() => {
-    if (ethers.utils.isAddress(userAddress))
+    if (utils.isAddress(userAddress))
       getXP(userAddress).then((res) => {
         if (res) setXPDataObj(res);
       });

--- a/packages/web/utils/playerHelpers.ts
+++ b/packages/web/utils/playerHelpers.ts
@@ -4,7 +4,7 @@ import GuildCoverImageFull from 'assets/guild-background-full.jpeg';
 import GuildCoverImageSmall from 'assets/guild-background-small.jpeg';
 import PlayerCoverImageFull from 'assets/player-background-full.jpg';
 import PlayerCoverImageSmall from 'assets/player-background-small.jpg';
-import { ethers } from 'ethers';
+import { utils } from 'ethers';
 import { AccountType_Enum, Player } from 'graphql/autogen/types';
 import { GuildPlayer } from 'graphql/types';
 
@@ -67,7 +67,7 @@ export const formatAddress = (address = ''): string =>
   `${address.slice(0, 6)}…${address.slice(-4)}`;
 
 export const formatIfAddress = (username = ''): string =>
-  ethers.utils.isAddress(username) ? formatAddress(username) : username;
+  utils.isAddress(username) ? formatAddress(username) : username;
 
 export const getPlayerURL = (
   player?: Maybe<Player | GuildPlayer>,


### PR DESCRIPTION
## Overview

This fixes an issue where players that have multiple eth addresses in the SC Ledger aren't getting their XP updated properly during the sync job.

Closes #1243 

Paired with @dysbulic 

I tested it locally by manually setting vid's XP to lower numbers and then running the sync job. Seems to work.
