### PR TITLE
Fix the XP command on the discord bot

### DIFF
--- a/packages/discord-bot/src/discord/commands/getXp.ts
+++ b/packages/discord-bot/src/discord/commands/getXp.ts
@@ -146,9 +146,9 @@ const scAliasMatchesDiscordId = (
   discordAccount: SCAlias,
   targetUserDiscordID: Snowflake,
 ) => {
-  const [, , , , discordId] = sc.core.graph.NodeAddress.toParts(
+  const [discordId] = sc.core.graph.NodeAddress.toParts(
     discordAccount.address,
-  );
+  ).slice(-1);
   if (discordId === targetUserDiscordID) {
     return discordId;
   }

--- a/packages/discord-bot/src/discord/commands/getXp.ts
+++ b/packages/discord-bot/src/discord/commands/getXp.ts
@@ -146,7 +146,7 @@ const scAliasMatchesDiscordId = (
   discordAccount: SCAlias,
   targetUserDiscordID: Snowflake,
 ) => {
-  const [, , , discordId] = sc.core.graph.NodeAddress.toParts(
+  const [, , , , discordId] = sc.core.graph.NodeAddress.toParts(
     discordAccount.address,
   );
   if (discordId === targetUserDiscordID) {


### PR DESCRIPTION
## Overview

Fixes #1284 

## Implementation

I fixed parsing of `discordId` from a sourcecred address. I suspect this broken during our last sourcecred upgrade. These homemade utilities to parse SC internals are brittle; best would be to contribute them back to SC to be used by everybody.