### PR TITLE
Fixing changed parameter for `busboy.on('file')`

### DIFF
--- a/packages/web/lib/hooks/useUser.ts
+++ b/packages/web/lib/hooks/useUser.ts
@@ -38,6 +38,10 @@ export const useUser = ({
     // eslint-disable-next-line no-console
     console.error(`useUser Error: ${error.message}`);
   }
+  if (!authToken && connected) {
+    // eslint-disable-next-line no-console
+    console.warn('`authToken` unset when connected');
+  }
 
   useEffect(() => {
     if (!redirectTo || fetching || connecting) return;


### PR DESCRIPTION
## Overview

**What features/fixes does this PR include?**

`busboy` was recently upgraded and the signature for the `on('file')` method changed. The third argument was a filename, now it is an object with a name, type, encoding, and other info.

This was causing the `/ai/storage` endpoint to fail with a 'received an Object, expected a string` error.

This PR extracts the filename from the argument so that the method completes successfully.

## Follow up Improvement Ideas

This is a simple bugfix, nothing else should need to be done other than some day the addition of some automated testing to catch stuff like this.

## Implementation

I put braces around what once was a string and is now an object to pull the appropriate field out.