### PR TITLE
Meta fam dashboard links

### DIFF
--- a/packages/web/pages/index.tsx
+++ b/packages/web/pages/index.tsx
@@ -1,4 +1,4 @@
-import { Box, Button, Text, VStack } from '@metafam/ds';
+import { Box, Button, Text, Tooltip, VStack } from '@metafam/ds';
 import { PageContainer } from 'components/Container';
 import { Build } from 'components/Landing/Build';
 import { Game } from 'components/Landing/Game';
@@ -14,7 +14,14 @@ import { HeadComponent } from 'components/Seo';
 // import { ScrollTrigger } from 'gsap/dist/ScrollTrigger';
 import { useRouter } from 'next/router';
 import React, { useCallback, useEffect, useRef, useState } from 'react';
-import { FaDiscord, FaGithub, FaTwitter } from 'react-icons/fa';
+import {
+  FaDiscord,
+  FaGithub,
+  FaHome,
+  FaTrophy,
+  FaTwitter,
+  FaUserCircle,
+} from 'react-icons/fa';
 
 export const getStaticProps = async () => ({
   props: {
@@ -165,15 +172,6 @@ export const Socials: React.FC = () => (
       },
     }}
   >
-    <Text
-      as="span"
-      sx={{
-        flex: 1,
-        transform: ' translateY(40px) rotate(-90deg)',
-      }}
-    >
-      Follow us
-    </Text>
     <MetaLink href="https://github.com/metafam" isExternal>
       <FaGithub />
     </MetaLink>
@@ -182,6 +180,30 @@ export const Socials: React.FC = () => (
     </MetaLink>
     <MetaLink href="https://twitter.com/metafam" isExternal>
       <FaTwitter />
+    </MetaLink>
+    <MetaLink href="/players">
+      <Tooltip label="Leaderboard" hasArrow placement="right">
+        <span>
+          {' '}
+          <FaTrophy />{' '}
+        </span>
+      </Tooltip>
+    </MetaLink>
+    <MetaLink href="/dashboard">
+      <Tooltip label="Dashboard" hasArrow placement="right">
+        <span>
+          {' '}
+          <FaHome />{' '}
+        </span>
+      </Tooltip>
+    </MetaLink>
+    <MetaLink href="/me">
+      <Tooltip label="Player Profile" hasArrow placement="right">
+        <span>
+          {' '}
+          <FaUserCircle />{' '}
+        </span>
+      </Tooltip>
     </MetaLink>
   </VStack>
 );

--- a/packages/web/pages/index.tsx
+++ b/packages/web/pages/index.tsx
@@ -1,4 +1,4 @@
-import { Box, Button, Text, Tooltip, VStack } from '@metafam/ds';
+import { Box, Button, Icon, Text, Tooltip, VStack } from '@metafam/ds';
 import { PageContainer } from 'components/Container';
 import { Build } from 'components/Landing/Build';
 import { Game } from 'components/Landing/Game';
@@ -172,37 +172,46 @@ export const Socials: React.FC = () => (
       },
     }}
   >
-    <MetaLink href="https://github.com/metafam" isExternal>
-      <FaGithub />
+    <MetaLink href="https://github.com/metafam" my={3} isExternal>
+      <Tooltip label="Github" hasArrow placement="right">
+        <Box as="span">
+          <FaGithub />
+        </Box>
+      </Tooltip>
     </MetaLink>
     <MetaLink href="https://discord.com/invite/metagame" isExternal>
-      <FaDiscord />
+      <Tooltip label="Discord" hasArrow placement="right">
+        <Box as="span">
+          <FaDiscord />
+        </Box>
+      </Tooltip>
     </MetaLink>
     <MetaLink href="https://twitter.com/metafam" isExternal>
-      <FaTwitter />
+      <Tooltip label="Twitter" hasArrow placement="right">
+        <Box as="span">
+          <FaTwitter />
+        </Box>
+      </Tooltip>
     </MetaLink>
     <MetaLink href="/players">
       <Tooltip label="Leaderboard" hasArrow placement="right">
-        <span>
-          {' '}
-          <FaTrophy />{' '}
-        </span>
+        <Box as="span">
+          <FaTrophy />
+        </Box>
       </Tooltip>
     </MetaLink>
     <MetaLink href="/dashboard">
       <Tooltip label="Dashboard" hasArrow placement="right">
-        <span>
-          {' '}
-          <FaHome />{' '}
-        </span>
+        <Box as="span">
+          <FaHome />
+        </Box>
       </Tooltip>
     </MetaLink>
     <MetaLink href="/me">
       <Tooltip label="Player Profile" hasArrow placement="right">
-        <span>
-          {' '}
-          <FaUserCircle />{' '}
-        </span>
+        <Box as="span">
+          <FaUserCircle />
+        </Box>
       </Tooltip>
     </MetaLink>
   </VStack>

--- a/packages/web/pages/index.tsx
+++ b/packages/web/pages/index.tsx
@@ -1,4 +1,4 @@
-import { Box, Button, Icon, Text, Tooltip, VStack } from '@metafam/ds';
+import { Box, Button, Text, Tooltip, VStack } from '@metafam/ds';
 import { PageContainer } from 'components/Container';
 import { Build } from 'components/Landing/Build';
 import { Game } from 'components/Landing/Game';

--- a/packages/web/pages/index.tsx
+++ b/packages/web/pages/index.tsx
@@ -29,6 +29,7 @@ export const getStaticProps = async () => ({
   },
 });
 
+
 const ArrowUp: React.FC = () => (
   <svg strokeWidth={0} viewBox="0 0 16 16" focusable="false">
     <defs>

--- a/packages/web/pages/index.tsx
+++ b/packages/web/pages/index.tsx
@@ -29,7 +29,6 @@ export const getStaticProps = async () => ({
   },
 });
 
-
 const ArrowUp: React.FC = () => (
   <svg strokeWidth={0} viewBox="0 0 16 16" focusable="false">
     <defs>


### PR DESCRIPTION
THIS IS A COPY OF [THIS PR](https://github.com/MetaFam/TheGame/pull/1288)

Used Tooltip and 3 new FA Icons to implement this change. Needed the <span> tags to fix the tooltip popup's placement relative to the icon. Couldn't find anything on this in the Chakra Docs or Github

## Overview

**What features/fixes does this PR include?**
MyMeta Dashboard Social Links

**Please provide the GitHub issue number**
ISSUE #1236 

Closes #

## Follow up Improvement Ideas

We could potentially get some custom Icons make from a designer if we see fit...

## Implementation

Used Tooltip and 3 new FA Icons to implement this change. Needed the <span> tags to fix the tooltip popup's placement relative to the icon. Couldn't find anything on this in the Chakra Docs or Github

**Describe technical (nontrivial / non-obvious) parts of your code**

**Side effects**

We would need to have translations for the tooltip text at some point

<!---
Server deploy required?
Desktop apps?
MS Teams app?
Onboarding?
Backwards compatibility?
Performance sensitive changes?
Are translations required?
-->

## Assets

[Include screenshots/videos if it makes reviewing easier.]
