### PR TITLE
Landing page small fixes 1313

### DIFF
--- a/packages/web/components/Landing/Build.tsx
+++ b/packages/web/components/Landing/Build.tsx
@@ -64,9 +64,8 @@ export const Build: React.FC = () => {
           <Text fontSize={{ base: 'xl', '2xl': '3xl' }}>
             People are waking up to the{' '}
             <Text as="strong" className="gradient-text">
-              world-shaping potential of Web3 technologies
+              world-shaping potential of Web3 technologies.
             </Text>
-            .
           </Text>
 
           <Text pt={{ base: 4, md: 8 }}>

--- a/packages/web/components/Landing/Build.tsx
+++ b/packages/web/components/Landing/Build.tsx
@@ -54,16 +54,25 @@ export const Build: React.FC = () => {
         >
           <Text fontSize={{ base: 'xl', '2xl': '3xl' }}>
             People are waking up to the{' '}
-            <strong>world-shaping potential of Web3 technologies</strong>.
+            <Text as="strong" className="gradient-text">
+              world-shaping potential of Web3 technologies
+            </Text>
+            .
           </Text>
 
           <Text pt={{ base: 4, md: 8 }}>
             They are grabbing the opportunity to{' '}
-            <strong>build the future</strong> they want to live in.
+            <Text as="strong" className="gradient-text">
+              build the future
+            </Text>{' '}
+            they want to live in.
           </Text>
           <Text pt={{ base: 4, md: 8 }}>
             Web3 technologies are allowing us to{' '}
-            <strong>reimagine socioeconomic systems</strong> from the ground up.
+            <Text as="strong" className="gradient-text">
+              reimagine socioeconomic systems
+            </Text>{' '}
+            from the ground up.
           </Text>
         </Flex>
       </Container>

--- a/packages/web/components/Landing/Build.tsx
+++ b/packages/web/components/Landing/Build.tsx
@@ -52,6 +52,15 @@ export const Build: React.FC = () => {
           opacity={onScreen ? 1 : 0}
           transition="transform 0.3s 0.1s ease-in-out, opacity 0.5s 0.2s ease-in"
         >
+          <Text
+            as="h2"
+            pb={{ base: '1.188rem', '2xl': '3xl' }}
+            fontSize={{ base: '3xl', '2xl': '5xl' }}
+            fontWeight="bold"
+            className="gradient-text"
+          >
+            While you’re sleeping…
+          </Text>
           <Text fontSize={{ base: 'xl', '2xl': '3xl' }}>
             People are waking up to the{' '}
             <Text as="strong" className="gradient-text">

--- a/packages/web/components/Landing/LandingHeader.tsx
+++ b/packages/web/components/Landing/LandingHeader.tsx
@@ -180,21 +180,28 @@ export const LandingHeader: React.FC = () => {
               toggle={toggle}
               setToggle={setToggle}
             >
-              3. Build the future!
+              3. While you’re sleeping&hellip;
             </NavLink>
             <NavLink
               target="the-wild-web"
               toggle={toggle}
               setToggle={setToggle}
             >
-              4. The Wild Web
+              4. The problem?
+            </NavLink>
+            <NavLink
+              target="why-are-we-here"
+              toggle={toggle}
+              setToggle={setToggle}
+            >
+              5. Why are we here?
             </NavLink>
             <NavLink target="what-do" toggle={toggle} setToggle={setToggle}>
-              5. What do?
+              6. What do?
             </NavLink>
 
             <NavLink target="join-us" toggle={toggle} setToggle={setToggle}>
-              6. Join us!
+              7. Join us!
             </NavLink>
           </VStack>
         </Stack>

--- a/packages/web/components/Landing/WhyAreWeHere.tsx
+++ b/packages/web/components/Landing/WhyAreWeHere.tsx
@@ -7,10 +7,10 @@ import { useRef } from 'react';
 
 import { LandingNextButton } from './LandingNextButton';
 
-export const WildWeb: React.FC = () => {
+export const WhyAreWeHere: React.FC = () => {
   const ref = useRef<HTMLDivElement>(null);
   const onScreen = useOnScreen(ref);
-  const section = 'the-wild-web';
+  const section = 'why-are-we-here';
   const responsiveBg = useBreakpointValue({
     base: BackgroundImageMobile,
     md: BackgroundImageDesktop,
@@ -60,36 +60,50 @@ export const WildWeb: React.FC = () => {
             fontWeight="bold"
             className="gradient-text"
           >
-            The problem?
+            Why are we here?
           </Text>
           <Text
             pb={{ base: '1.188rem', '2xl': '3xl' }}
             fontSize={{ base: 'xl', '2xl': '3xl' }}
           >
-            A new world is being built but it’s{' '}
+            To help{' '}
             <Text as="strong" className="gradient-text">
-              hard to&nbsp;navigate
+              you
+            </Text>{' '}
+            tame it.
+          </Text>
+          <Text pb={{ base: '1.188rem', '2xl': '2.188rem' }}>
+            We are here to help transform{' '}
+            <Text as="strong" className="gradient-text">
+              the wild web
+            </Text>{' '}
+            into a{' '}
+            <Text as="strong" className="gradient-text">
+              web of opportunity
             </Text>
             .
           </Text>
           <Text pb={{ base: '1.188rem', '2xl': '2.188rem' }}>
-            The resources, building blocks, &amp; tools are all over the place{' '}
+            To help you break into this brave new world, avoid traps,{' '}
             <Text as="strong" className="gradient-text">
-              but the maps are inexistent
+              level up
+            </Text>{' '}
+            &amp;{' '}
+            <Text as="strong" className="gradient-text">
+              make an impact
             </Text>
             .
           </Text>
           <Text pb={{ base: '1.188rem', '2xl': '2.188rem' }}>
-            There are pitfalls, gold-rushing cowboys &amp; snake oil salesmen at
-            every corner.
-          </Text>
-
-          <Text as="strong" className="gradient-text" textTransform="uppercase">
-            It’s a Wild Web.
+            To build a new kind of socioeconomic system, optimized for{' '}
+            <Text as="strong" className="gradient-text">
+              wellbeing over profit
+            </Text>
+            .
           </Text>
         </Box>
       </Container>
-      <LandingNextButton section="why-are-we-here" />
+      <LandingNextButton section="what-do" />
     </FullPageContainer>
   );
 };

--- a/packages/web/components/Landing/WhyAreWeHere.tsx
+++ b/packages/web/components/Landing/WhyAreWeHere.tsx
@@ -79,9 +79,8 @@ export const WhyAreWeHere: React.FC = () => {
             </Text>{' '}
             into a{' '}
             <Text as="strong" className="gradient-text">
-              web of opportunity
+              web of opportunity.
             </Text>
-            .
           </Text>
           <Text pb={{ base: '1.188rem', '2xl': '2.188rem' }}>
             To help you break into this brave new world, avoid traps,{' '}
@@ -90,16 +89,14 @@ export const WhyAreWeHere: React.FC = () => {
             </Text>{' '}
             &amp;{' '}
             <Text as="strong" className="gradient-text">
-              make an impact
+              make an impact.
             </Text>
-            .
           </Text>
           <Text pb={{ base: '1.188rem', '2xl': '2.188rem' }}>
             To build a new kind of socioeconomic system, optimized for{' '}
             <Text as="strong" className="gradient-text">
-              wellbeing over profit
+              wellbeing over profit.
             </Text>
-            .
           </Text>
         </Box>
       </Container>

--- a/packages/web/components/Landing/WildWeb.tsx
+++ b/packages/web/components/Landing/WildWeb.tsx
@@ -72,7 +72,7 @@ export const WildWeb: React.FC = () => {
             </Text>
           </Text>
           <Text pb={{ base: '1.188rem', '2xl': '2.188rem' }}>
-            The resources, building blocks, &amp; tools are all over the place{' '}
+            The resources, building blocks &amp; tools are all over the place{' '}
             <Text as="strong" className="gradient-text">
               but the maps are inexistent.
             </Text>

--- a/packages/web/components/Landing/WildWeb.tsx
+++ b/packages/web/components/Landing/WildWeb.tsx
@@ -68,16 +68,14 @@ export const WildWeb: React.FC = () => {
           >
             A new world is being built but it’s{' '}
             <Text as="strong" className="gradient-text">
-              hard to&nbsp;navigate
+              hard to&nbsp;navigate.
             </Text>
-            .
           </Text>
           <Text pb={{ base: '1.188rem', '2xl': '2.188rem' }}>
             The resources, building blocks, &amp; tools are all over the place{' '}
             <Text as="strong" className="gradient-text">
-              but the maps are inexistent
+              but the maps are inexistent.
             </Text>
-            .
           </Text>
           <Text pb={{ base: '1.188rem', '2xl': '2.188rem' }}>
             There are pitfalls, gold-rushing cowboys &amp; snake oil salesmen at

--- a/packages/web/components/Landing/WildWeb.tsx
+++ b/packages/web/components/Landing/WildWeb.tsx
@@ -58,18 +58,23 @@ export const WildWeb: React.FC = () => {
             fontSize={{ base: 'xl', '2xl': '3xl' }}
           >
             A new world is being built but it's{' '}
-            <Text as="strong">hard to&nbsp;navigate.</Text>
+            <Text as="strong" className="gradient-text">
+              hard to&nbsp;navigate.
+            </Text>
           </Text>
           <Text pb={{ base: '1.188rem', '2xl': '2.188rem' }}>
             The resources, building blocks, &amp; tools are all over the place{' '}
-            <Text as="strong">but the maps are inexistent</Text>.
+            <Text as="strong" className="gradient-text">
+              but the maps are inexistent
+            </Text>
+            .
           </Text>
           <Text pb={{ base: '1.188rem', '2xl': '2.188rem' }}>
             There are pitfalls, gold rushing cowboys &amp; snake oil salesmen at
             every corner.
           </Text>
 
-          <Text as="strong" textTransform="uppercase">
+          <Text as="strong" className="gradient-text" textTransform="uppercase">
             It’s a Wild Web.
           </Text>
         </Box>

--- a/packages/web/components/Landing/WildWeb.tsx
+++ b/packages/web/components/Landing/WildWeb.tsx
@@ -54,10 +54,19 @@ export const WildWeb: React.FC = () => {
           transition="transform 0.3s 0.1s ease-in-out, opacity 0.5s 0.2s ease-in"
         >
           <Text
+            as="h2"
+            pb={{ base: '1.188rem', '2xl': '3xl' }}
+            fontSize={{ base: '3xl', '2xl': '5xl' }}
+            fontWeight="bold"
+            className="gradient-text"
+          >
+            The problem?
+          </Text>
+          <Text
             pb={{ base: '1.188rem', '2xl': '3xl' }}
             fontSize={{ base: 'xl', '2xl': '3xl' }}
           >
-            A new world is being built but it's{' '}
+            A new world is being built but it’s{' '}
             <Text as="strong" className="gradient-text">
               hard to&nbsp;navigate.
             </Text>

--- a/packages/web/components/Landing/WildWeb.tsx
+++ b/packages/web/components/Landing/WildWeb.tsx
@@ -58,15 +58,15 @@ export const WildWeb: React.FC = () => {
             fontSize={{ base: 'xl', '2xl': '3xl' }}
           >
             A new world is being built but it's{' '}
-            <Text as="strong">hard to navigate.</Text>
+            <Text as="strong">hard to&nbsp;navigate.</Text>
           </Text>
           <Text pb={{ base: '1.188rem', '2xl': '2.188rem' }}>
             The resources, building blocks, &amp; tools are all over the place{' '}
             <Text as="strong">but the maps are inexistent</Text>.
           </Text>
           <Text pb={{ base: '1.188rem', '2xl': '2.188rem' }}>
-            There are pitfalls, gold rushing cowboys, &amp; snake oil salesmen
-            at every corner.
+            There are pitfalls, gold rushing cowboys &amp; snake oil salesmen at
+            every corner.
           </Text>
 
           <Text as="strong" textTransform="uppercase">

--- a/packages/web/pages/index.tsx
+++ b/packages/web/pages/index.tsx
@@ -6,6 +6,7 @@ import { Intro } from 'components/Landing/Intro';
 import { JoinUs } from 'components/Landing/JoinUs';
 import { LandingHeader } from 'components/Landing/LandingHeader';
 import { WhatDo } from 'components/Landing/WhatDo';
+import { WhyAreWeHere } from 'components/Landing/WhyAreWeHere';
 import { WildWeb } from 'components/Landing/WildWeb';
 import { MetaLink } from 'components/Link';
 import { HeadComponent } from 'components/Seo';
@@ -125,8 +126,9 @@ const Landing: React.FC = () => {
         <Game /> {/* section 1 */}
         <Build /> {/* section 2 */}
         <WildWeb /> {/* section 3 */}
-        <WhatDo /> {/* section 4 */}
-        <JoinUs /> {/* section 5 */}
+        <WhyAreWeHere /> {/* section 4 */}
+        <WhatDo /> {/* section 5 */}
+        <JoinUs /> {/* section 6 */}
       </PageContainer>
       <SectionWayPoints currentWaypoint={section} />
       <Socials />
@@ -335,16 +337,23 @@ export const SectionWayPoints = ({
           <Button
             className={currentWaypoint === 4 ? 'active' : ''}
             colorScheme="ghost"
-            onClick={() => handleSectionNav('what-do')}
+            onClick={() => handleSectionNav('why-are-we-here')}
           >
             <Text as="span">05</Text>
           </Button>
           <Button
             className={currentWaypoint === 5 ? 'active' : ''}
             colorScheme="ghost"
-            onClick={() => handleSectionNav('join-us')}
+            onClick={() => handleSectionNav('what-do')}
           >
             <Text as="span">06</Text>
+          </Button>
+          <Button
+            className={currentWaypoint === 6 ? 'active' : ''}
+            colorScheme="ghost"
+            onClick={() => handleSectionNav('join-us')}
+          >
+            <Text as="span">07</Text>
           </Button>
         </VStack>
       </Box>


### PR DESCRIPTION
## Overview

**What features/fixes does this PR include?**
- Text changes on Wild Web slide ✔
- Rainbow gradient on bold text ✔
- Add headers to the pages (should also be renamed on the side menu) as recommended ✔❔
- Added a new slide to bridge the transition from "its a wild web" to "we produce content..." ✔❔

**Please provide the GitHub issue number**
#1313 

## Follow up Improvement Ideas

The rainbow gradient text is hard to read when it goes over a similar colour background image. A typical solution is some drop shadow.

## Implementation

**Describe technical (nontrivial / non-obvious) parts of your code**
One of the issues was an orphaned word on wide screen views. The idea was to make the container more narrow so the word 'navigate' wasn't on a line by itself.

... to  
navigate
vs
...  
to navigate

The easy way to fix that was to join the two words with an \&nbsp; character. You'll see 'to\&nbsp;navigate' in the changed files below.

Otherwise, nothing special - just basic edits of code using existing slides/nav/etc as a base.

**Side effects**
n/a

## Assets

![1313-nbsp-and-rainbow](https://user-images.githubusercontent.com/92962228/180116167-ea6d8962-09f7-4e3c-88dd-7ef2f7d8033d.png)
![1313-nbsp-and-rainbow_sm](https://user-images.githubusercontent.com/92962228/180116176-839be6b2-8354-414d-8de8-4c8d954b1cad.png)

