### PR TITLE
add query to the wiki url to hide the header

### DIFF
--- a/packages/web/pages/community/events.tsx
+++ b/packages/web/pages/community/events.tsx
@@ -5,7 +5,7 @@ const EventsPage: React.FC = () => (
   <EmbedContainer
     title="MetaGame Events"
     description={descriptions.events}
-    url="//wiki.metagame.wtf/docs/resources/calendar"
+    url="//wiki.metagame.wtf/docs/resources/calendar?metaos=true"
   />
 );
 

--- a/packages/web/pages/learn/playbooks.tsx
+++ b/packages/web/pages/learn/playbooks.tsx
@@ -5,7 +5,7 @@ const PlaybooksPage: React.FC = () => (
   <EmbedContainer
     title="MetaGame Playbooks"
     description={descriptions.playbooks}
-    url="https://wiki.metagame.wtf/docs/playbooks/browse"
+    url="https://wiki.metagame.wtf/playbooks/how-to-make-it-without-technical-skills/?metaos=true"
   />
 );
 

--- a/packages/web/pages/learn/thegreathouses.tsx
+++ b/packages/web/pages/learn/thegreathouses.tsx
@@ -5,7 +5,7 @@ const TheGreatHousesPage: React.FC = () => (
   <EmbedContainer
     title="The Great Houses of MetaGame"
     description={descriptions.thegreathouses}
-    url="https://wiki.metagame.wtf/docs/great-houses/house-of-daos/"
+    url="https://wiki.metagame.wtf/great-houses/house-of-daos/?metaos=true"
   />
 );
 

--- a/packages/web/pages/learn/wiki.tsx
+++ b/packages/web/pages/learn/wiki.tsx
@@ -5,7 +5,7 @@ const WikiEmbedPage: React.FC = () => (
   <EmbedContainer
     title="MetaGame Wiki"
     description={descriptions.wiki}
-    url="https://wiki.metagame.wtf/docs/wtf-is-metagame/wtf-is-metagame"
+    url="https://wiki.metagame.wtf?metaos=true"
   />
 );
 

--- a/packages/web/utils/menuLinks.ts
+++ b/packages/web/utils/menuLinks.ts
@@ -106,8 +106,7 @@ export const MenuSectionLinks: MenuLinkSet[] = [
       {
         title: 'Playbooks',
         explainerText: descriptions.playbooks,
-        url:
-          'https://wiki.metagame.wtf/docs/playbooks/how-to-make-it-without-technical-skills',
+        url: '/learn/playbooks',
         icon: 'playbooks',
       },
       // {


### PR DESCRIPTION
- wiki issue [355](https://github.com/MetaFam/metagame-wiki/issues/355)
- this improves display of the wiki when it is embedded in MetaOS.

## Overview

**What features/fixes does this PR include?**
adds a query to the url for the wiki so it hides and applies some specific styles to the wiki header when it is embedded in metaOS. 
We've also removed the old wiki homepage and added a 301 redirect in Vercel to handle the removal of `/docs/` from wiki URLs.

**Please provide the GitHub issue number**
[Wiki issue 355](https://github.com/MetaFam/metagame-wiki/issues/355)

*Requires https://github.com/MetaFam/metagame-wiki/pull/356 to be merged first.*

## Follow up Improvement Ideas

- [ ] please list any improvement/ideas

## Implementation

**Describe technical (nontrivial / non-obvious) parts of your code**

**Side effects**

<!---
Server deploy required?
Desktop apps?
MS Teams app?
Onboarding?
Backwards compatibility?
Performance sensitive changes?
Are translations required?
-->

## Assets

[Include screenshots/videos if it makes reviewing easier.]
