### PR TITLE
Styling of Account dropdown now consistent w/MegaMenu.

### DIFF
--- a/packages/design-system/src/icons/MenuArrow.tsx
+++ b/packages/design-system/src/icons/MenuArrow.tsx
@@ -1,0 +1,15 @@
+import { createIcon } from '@chakra-ui/icons';
+import * as React from 'react';
+
+export const MenuArrow = createIcon({
+  displayName: 'MenuArrow',
+  path: (
+    <g>
+      <path
+        d="M12 0L24 12C14.6274 12 9.37258 12 0 12L12 0Z"
+        fill="currentColor"
+      />
+    </g>
+  ),
+  viewBox: '0 0 24 24',
+});

--- a/packages/design-system/src/icons/index.ts
+++ b/packages/design-system/src/icons/index.ts
@@ -7,6 +7,7 @@ export { GnosisIcon } from './GnosisIcon';
 export { Icon3box } from './Icon3box';
 export { LogOut } from './LogOut';
 export { MeetWithWalletIcon } from './MeetWithWalletIcon';
+export { MenuArrow } from './MenuArrow';
 export { MetaMaskIcon } from './MetaMaskIcon';
 export { PolygonIcon } from './PolygonIcon';
 export { Profile } from './Profile';

--- a/packages/web/components/MegaMenu/DesktopPlayerStats.tsx
+++ b/packages/web/components/MegaMenu/DesktopPlayerStats.tsx
@@ -1,6 +1,7 @@
 import {
   Dashboard,
   Flex,
+  Icon,
   LogOut,
   Menu,
   MenuButton,
@@ -26,6 +27,7 @@ export const DesktopPlayerStats: React.FC<PlayerStatsProps> = ({ player }) => {
   return (
     <Flex align="center" justifyContent="flex-end">
       <XPSeedsBalance totalXP={player.totalXP} />
+
       <Menu>
         <MenuButton
           bg="transparent"
@@ -41,37 +43,94 @@ export const DesktopPlayerStats: React.FC<PlayerStatsProps> = ({ player }) => {
             _hover={{ transform: 'scale(0.9)' }}
           />
         </MenuButton>
-        <MenuList mt="8px" color="black">
+        <MenuList
+          mt="8px"
+          color="white"
+          boxShadow="2xl"
+          bg="linear-gradient(180deg, rgba(42, 31, 71, 0.9) 6.18%, rgba(17, 3, 32, 0.86) 140%)"
+          borderRadius="md"
+          border={0}
+          px={2}
+          position="relative"
+        >
+          <Icon
+            position="absolute"
+            left="calc(92% - 1.25rem)"
+            top={-3}
+            w={6}
+            h={'auto'}
+            opacity={1}
+            transition="opacity 0.2s"
+            zIndex={2}
+          >
+            <path
+              d="M12 0L24 12C14.6274 12 9.37258 12 0 12L12 0Z"
+              fill="rgba(42, 31, 71, 0.9)"
+            />
+          </Icon>
           <MetaLink
-            color="black"
+            color="white"
             href={getPlayerURL(player) ?? '/'}
             _hover={{ textDecoration: 'none' }}
           >
-            <MenuItem>
+            <MenuItem
+              sx={{
+                '&:hover, &:active, &:focus': {
+                  bg: 'rgba(0,0,0,0.56)',
+                  color: 'white',
+                  borderRadius: 'md',
+                },
+              }}
+            >
               <Profile w={4} h={4} mr={4} /> View Profile
             </MenuItem>
           </MetaLink>
           <MetaLink
-            color="black"
+            color="white"
             href={'/profile/setup'}
             _hover={{ textDecoration: 'none' }}
           >
-            <MenuItem>
+            <MenuItem
+              sx={{
+                '&:hover, &:active, &:focus': {
+                  bg: 'rgba(0,0,0,0.56)',
+                  color: 'white',
+                  borderRadius: 'md',
+                },
+              }}
+            >
               <Profile w={4} h={4} mr={4} /> Profile Wizard
             </MenuItem>
           </MetaLink>
           <MetaLink
-            color="black"
+            color="white"
             href={'/dashboard'}
             _hover={{ textDecoration: 'none' }}
           >
-            <MenuItem>
-              <Dashboard w={4} h={4} mr={4} color="red.500" />
+            <MenuItem
+              sx={{
+                '&:hover, &:active, &:focus': {
+                  bg: 'rgba(0,0,0,0.56)',
+                  color: 'white',
+                  borderRadius: 'md',
+                },
+              }}
+            >
+              <Dashboard w={4} h={4} mr={4} fill="white" />
               Dashboard
             </MenuItem>
           </MetaLink>
-          <MenuItem onClick={disconnect}>
-            <LogOut w={4} h={4} mr={4} />
+          <MenuItem
+            onClick={disconnect}
+            sx={{
+              '&:hover, &:active, &:focus': {
+                bg: 'rgba(0,0,0,0.56)',
+                color: 'white',
+                borderRadius: 'md',
+              },
+            }}
+          >
+            <LogOut w={4} h={4} mr={4} fill="white" />
             Disconnect
           </MenuItem>
         </MenuList>

--- a/packages/web/components/MegaMenu/DesktopPlayerStats.tsx
+++ b/packages/web/components/MegaMenu/DesktopPlayerStats.tsx
@@ -4,6 +4,7 @@ import {
   Icon,
   LogOut,
   Menu,
+  MenuArrow,
   MenuButton,
   MenuItem,
   MenuList,
@@ -54,20 +55,17 @@ export const DesktopPlayerStats: React.FC<PlayerStatsProps> = ({ player }) => {
           position="relative"
         >
           <Icon
+            as={MenuArrow}
+            color="rgba(42, 31, 71, 0.9)"
             position="absolute"
             left="calc(92% - 1.25rem)"
             top={-3}
             w={6}
-            h={'auto'}
+            h="auto"
             opacity={1}
             transition="opacity 0.2s"
             zIndex={2}
-          >
-            <path
-              d="M12 0L24 12C14.6274 12 9.37258 12 0 12L12 0Z"
-              fill="rgba(42, 31, 71, 0.9)"
-            />
-          </Icon>
+          />
           <MetaLink
             color="white"
             href={getPlayerURL(player) ?? '/'}

--- a/packages/web/components/MegaMenu/MegaMenuFooter.tsx
+++ b/packages/web/components/MegaMenu/MegaMenuFooter.tsx
@@ -77,37 +77,79 @@ export const MegaMenuFooter = () => {
                 </Stack>
               </Flex>
             </MenuButton>
-            <MenuList color="black">
+            <MenuList
+              color="white"
+              boxShadow="2xl"
+              bg="rgba(0, 0, 0, 0.75)"
+              borderRadius="md"
+              border={0}
+              px={2}
+              position="relative"
+              transform="translateY(-7px)!important"
+            >
               <MetaLink
-                color="black"
+                color="white"
                 href={getPlayerURL(user) ?? '/'}
                 _hover={{ textDecoration: 'none' }}
               >
-                <MenuItem>
+                <MenuItem
+                  sx={{
+                    '&:hover, &:active, &:focus': {
+                      bg: 'rgba(0,0,0,0.56)',
+                      color: 'white',
+                      borderRadius: 'md',
+                    },
+                  }}
+                >
                   <Profile w={4} h={4} mr={4} /> View Profile
                 </MenuItem>
               </MetaLink>
               <MetaLink
-                color="black"
+                color="white"
                 href={'/profile/setup'}
                 _hover={{ textDecoration: 'none' }}
               >
-                <MenuItem>
+                <MenuItem
+                  sx={{
+                    '&:hover, &:active, &:focus': {
+                      bg: 'rgba(0,0,0,0.56)',
+                      color: 'white',
+                      borderRadius: 'md',
+                    },
+                  }}
+                >
                   <Profile w={4} h={4} mr={4} /> Profile Wizard
                 </MenuItem>
               </MetaLink>
               <MetaLink
-                color="black"
+                color="white"
                 href={'/dashboard'}
                 _hover={{ textDecoration: 'none' }}
               >
-                <MenuItem>
-                  <Dashboard w={4} h={4} mr={4} color="red.500" />
+                <MenuItem
+                  sx={{
+                    '&:hover, &:active, &:focus': {
+                      bg: 'rgba(0,0,0,0.56)',
+                      color: 'white',
+                      borderRadius: 'md',
+                    },
+                  }}
+                >
+                  <Dashboard w={4} h={4} mr={4} fill="white" color="red.500" />
                   Dashboard
                 </MenuItem>
               </MetaLink>
-              <MenuItem onClick={disconnect}>
-                <LogOut w={4} h={4} mr={4} />
+              <MenuItem
+                onClick={disconnect}
+                sx={{
+                  '&:hover, &:active, &:focus': {
+                    bg: 'rgba(0,0,0,0.56)',
+                    color: 'white',
+                    borderRadius: 'md',
+                  },
+                }}
+              >
+                <LogOut w={4} h={4} mr={4} fill="white" />
                 Disconnect
               </MenuItem>
             </MenuList>


### PR DESCRIPTION
- mobile has a flat bg to match the footer

## Overview

**What features/fixes does this PR include?**
Style updates to the Desktop & mobile versions of the Account dropdown in the MegaMenu.

**Please provide the GitHub issue number**
#1356 

Closes #1356 

## Follow up Improvement Ideas

- [ ] please list any improvement/ideas

## Implementation
Just some Chakra changes + an arrow icon added.

**Describe technical (nontrivial / non-obvious) parts of your code**

**Side effects**
None

## Assets
![image](https://user-images.githubusercontent.com/780350/194655093-1ef4e541-d8a0-4950-96c9-4dd4f409d4ed.png)

![image](https://user-images.githubusercontent.com/780350/194654784-27945eb1-1d08-4f22-ae28-535d571429a7.png)
