### PR TITLE
Feat/1354 display newsletter images

### DIFF
--- a/packages/web/components/Dashboard/LatestContent.tsx
+++ b/packages/web/components/Dashboard/LatestContent.tsx
@@ -27,7 +27,7 @@ export const LatestContent: React.FC = () => (
       }}
     >
       <Flex direction="column" w="100%" h="100%">
-        <TabList borderBottomWidth={0} pr={4} pl={2}>
+        <TabList borderBottomWidth={0} pr={4} pl={0}>
           {['Read', 'Listen', 'Watch'].map((title) => (
             <Tab
               key={title}

--- a/packages/web/components/Dashboard/LatestContentTabs/Listen.tsx
+++ b/packages/web/components/Dashboard/LatestContentTabs/Listen.tsx
@@ -59,7 +59,7 @@ export const Listen: React.FC = () => {
   };
 
   return (
-    <Box px={2}>
+    <Box px={2} pl={0}>
       {loading ? (
         <LoadingState />
       ) : (
@@ -71,7 +71,7 @@ export const Listen: React.FC = () => {
             backgroundColor="blackAlpha.500"
             borderRadius="md"
           >
-            <Heading size="xs" color="white" pb={4}>
+            <Heading size="xs" color="white" pb={4} fontWeight="normal">
               {podcast.title}
             </Heading>
             {podcast.showMore ? (

--- a/packages/web/components/Dashboard/LatestContentTabs/Read.tsx
+++ b/packages/web/components/Dashboard/LatestContentTabs/Read.tsx
@@ -1,4 +1,4 @@
-import { Box, Heading, Link, LoadingState, Text } from '@metafam/ds';
+import { Box, Heading, Image, Link, LoadingState, Text } from '@metafam/ds';
 import React from 'react';
 import useSWR from 'swr';
 
@@ -6,37 +6,68 @@ const fetcher = (url: string) => fetch(url).then((res) => res.json());
 
 export const Read: React.FC = () => {
   const { data, error } = useSWR('/api/feed', fetcher);
-
   return (
-    <Box px={2}>
+    <Box px={2} pl={0}>
       {data && data.response ? (
         data.response.items?.map(
-          (item: { title: string; description: string; link: string }) => (
+          (item: {
+            title: string;
+            description: string;
+            link: string;
+            enclosures: Record<string, string>[];
+          }) => (
             <Box
               key={item.title}
+              position="relative"
               mt={4}
-              p={6}
               backgroundColor="blackAlpha.500"
               borderRadius="md"
+              overflow="hidden"
+              sx={{
+                '&::after': {
+                  content: '""',
+                  position: 'absolute',
+                  inset: 0,
+                  backgroundColor: 'blackAlpha.700',
+                  zIndex: 1,
+                },
+              }}
             >
-              <Heading size="xs" color="white" pb={4}>
-                {item.title}
-              </Heading>
-              <Text dangerouslySetInnerHTML={{ __html: item.description }} />
-              <Link
-                href={item.link}
-                _hover={{ bg: 'none', textDecoration: 'none' }}
-                _focus={{ outline: 'none' }}
-              >
-                <Text
-                  cursor="pointer"
-                  color="blueLight"
-                  py={1}
-                  fontWeight="bold"
+              <Box position="relative" zIndex={5} p={6}>
+                <Heading size="xs" color="white" fontWeight="normal" pb={4}>
+                  {item.title}
+                </Heading>
+                <Text dangerouslySetInnerHTML={{ __html: item.description }} />
+                <Link
+                  href={item.link}
+                  _hover={{ bg: 'none', textDecoration: 'none' }}
+                  _focus={{ outline: 'none' }}
                 >
-                  Read Here
-                </Text>
-              </Link>
+                  <Text
+                    cursor="pointer"
+                    color="blueLight"
+                    py={1}
+                    fontWeight="bold"
+                  >
+                    Read Here
+                  </Text>
+                </Link>
+              </Box>
+              {item.enclosures &&
+                item.enclosures.length > 0 &&
+                item.enclosures[0].type === 'image/jpeg' && (
+                  <Box
+                    position="absolute"
+                    inset={0}
+                    width="full"
+                    height="full"
+                    bg="landingDarkGlass"
+                    bgImg={`url(${item.enclosures[0].url})`}
+                    bgSize="cover"
+                    opacity={0.2}
+                    zIndex={0}
+                  />
+                )}
             </Box>
           ),
         )

--- a/packages/web/components/Dashboard/LatestContentTabs/Read.tsx
+++ b/packages/web/components/Dashboard/LatestContentTabs/Read.tsx
@@ -1,4 +1,12 @@
-import { Box, Heading, Image, Link, LoadingState, Text } from '@metafam/ds';
+import {
+  AspectRatio,
+  Box,
+  Heading,
+  Image,
+  Link,
+  LoadingState,
+  Text,
+} from '@metafam/ds';
 import React from 'react';
 import useSWR from 'swr';
 
@@ -6,9 +14,6 @@ const fetcher = (url: string) => fetch(url).then((res) => res.json());
 
 export const Read: React.FC = () => {
   const { data, error } = useSWR('/api/feed', fetcher);
-
-  // eslint-disable-next-line no-console
-  console.log(data);
 
   return (
     <Box px={2} pl={0}>
@@ -22,99 +27,115 @@ export const Read: React.FC = () => {
           }) => {
             const image = item.enclosures[0].url;
             const resizedImage = image.replace(/\/h_[0-9]{2,}/gi, '/h_250'); // resize image to 250px height
-
+            const shortenedDescription = `${item.description.substring(
+              0,
+              125,
+            )}...`;
             return (
-              <Box
+              <AspectRatio
                 key={item.title}
+                ratio={16 / 9}
+                mt={4}
                 role="group"
                 position="relative"
-                mt={4}
                 backgroundColor="blackAlpha.500"
                 borderRadius="md"
                 overflow="hidden"
               >
-                <Box position="relative" zIndex={5} p={6}>
-                  <Heading
-                    size="xs"
-                    color="white"
-                    fontWeight="normal"
-                    pb={4}
-                    transition="all 0.2s ease-out"
-                    _groupHover={{ transform: 'translateY(-20px)', opacity: 0 }}
-                  >
-                    {item.title}
-                  </Heading>
-                  <Text
-                    dangerouslySetInnerHTML={{ __html: item.description }}
-                    transition="all 0.2s ease-out"
-                    _groupHover={{ transform: 'translateY(20px)', opacity: 0 }}
-                  />
-                  <Link
-                    display="inline-flex"
-                    href={item.link}
-                    px={2}
-                    _hover={{ bg: 'landingDarkGlass', textDecoration: 'none' }}
-                    _focus={{ outline: 'none' }}
-                    _groupHover={{
-                      bg: 'landingDarkGlass',
-                      textDecoration: 'none',
-                    }}
-                    borderRadius="md"
-                  >
-                    <Text
-                      cursor="pointer"
-                      color="blueLight"
-                      py={1}
-                      fontWeight="bold"
-                    >
-                      Read Here
-                    </Text>
-                  </Link>
-                </Box>
-                {item.enclosures &&
-                  item.enclosures.length > 0 &&
-                  item.enclosures[0].type === 'image/jpeg' && (
-                    <Box
-                      position="absolute"
-                      inset={0}
-                      width="full"
-                      height="full"
-                      opacity={0.2}
-                      zIndex={0}
-                      transition="opacity 0.3s ease-out"
-                      _groupHover={{ opacity: 0.9 }}
-                      sx={{
-                        '&::after': {
-                          content: '""',
-                          position: 'absolute',
-                          display: 'block',
-                          width: '100%',
-                          height: '100%',
-                          inset: 0,
-                          zIndex: 2,
-                          borderRadius: 'md',
-                          transition: 'all 0.2s',
-                          _groupHover: {
-                            boxShadow: '0 0 50px rgba(0, 0, 0, 0.9) inset',
-                          },
-                        },
+                <Box
+                  backgroundColor="blackAlpha.600"
+                  borderRadius="md"
+                  w="100%"
+                  h="100%"
+                  overflow="hidden"
+                >
+                  <Box position="relative" zIndex={5} p={6}>
+                    <Heading
+                      size="xs"
+                      color="white"
+                      fontWeight="normal"
+                      pb={4}
+                      transition="all 0.2s ease-out"
+                      _groupHover={{
+                        transform: 'translateY(-20px)',
+                        opacity: 0,
                       }}
                     >
-                      <Image
-                        src={resizedImage}
-                        alt={item.title}
+                      {item.title}
+                    </Heading>
+                    <Text
+                      dangerouslySetInnerHTML={{ __html: shortenedDescription }}
+                      transition="all 0.2s ease-out"
+                      _groupHover={{
+                        transform: 'translateY(20px)',
+                        opacity: 0,
+                      }}
+                    />
+                    <Link
+                      display="inline-flex"
+                      href={item.link}
+                      px={2}
+                      _hover={{
+                        bg: 'landingDarkGlass',
+                        textDecoration: 'none',
+                      }}
+                      _focus={{ outline: 'none' }}
+                      _groupHover={{
+                        bg: 'landingDarkGlass',
+                        textDecoration: 'none',
+                      }}
+                      borderRadius="md"
+                    >
+                      <Text
+                        cursor="pointer"
+                        color="blueLight"
+                        py={1}
+                        fontWeight="bold"
+                      >
+                        Read Here
+                      </Text>
+                    </Link>
+                  </Box>
+                  {item.enclosures &&
+                    item.enclosures.length > 0 &&
+                    item.enclosures[0].type === 'image/jpeg' && (
+                      <Box
+                        position="absolute"
+                        inset={0}
                         width="full"
                         height="full"
-                        objectFit="cover"
                         opacity={0.2}
-                        transition="opacity 0.3s ease-out"
-                        _groupHover={{ opacity: 1 }}
-                        loading="lazy"
                         zIndex={0}
-                      />
-                    </Box>
-                  )}
-              </Box>
+                        transition="opacity 0.3s 0.1s ease-out"
+                        _groupHover={{ opacity: 1 }}
+                        sx={{
+                          '&::after': {
+                            content: '""',
+                            position: 'absolute',
+                            display: 'block',
+                            width: '100%',
+                            height: '100%',
+                            inset: 0,
+                            zIndex: 2,
+                            borderRadius: 'md',
+                            transition: 'all 0.1s ease-out',
+                            boxShadow: '0 0 50px rgba(0, 0, 0, 0.9) inset',
+                          },
+                        }}
+                      >
+                        <Image
+                          src={resizedImage}
+                          alt={item.title}
+                          width="full"
+                          height="full"
+                          objectFit="cover"
+                          loading="lazy"
+                          zIndex={0}
+                        />
+                      </Box>
+                    )}
+                </Box>
+              </AspectRatio>
             );
           },
         )

--- a/packages/web/components/Dashboard/LatestContentTabs/Read.tsx
+++ b/packages/web/components/Dashboard/LatestContentTabs/Read.tsx
@@ -6,6 +6,10 @@ const fetcher = (url: string) => fetch(url).then((res) => res.json());
 
 export const Read: React.FC = () => {
   const { data, error } = useSWR('/api/feed', fetcher);
+
+  // eslint-disable-next-line no-console
+  console.log(data);
+
   return (
     <Box px={2} pl={0}>
       {data && data.response ? (
@@ -15,61 +19,104 @@ export const Read: React.FC = () => {
             description: string;
             link: string;
             enclosures: Record<string, string>[];
-          }) => (
-            <Box
-              key={item.title}
-              position="relative"
-              mt={4}
-              backgroundColor="blackAlpha.500"
-              borderRadius="md"
-              overflow="hidden"
-              sx={{
-                '&::after': {
-                  content: '""',
-                  position: 'absolute',
-                  inset: 0,
-                  backgroundColor: 'blackAlpha.700',
-                  zIndex: 1,
-                },
-              }}
-            >
-              <Box position="relative" zIndex={5} p={6}>
-                <Heading size="xs" color="white" fontWeight="normal" pb={4}>
-                  {item.title}
-                </Heading>
-                <Text dangerouslySetInnerHTML={{ __html: item.description }} />
-                <Link
-                  href={item.link}
-                  _hover={{ bg: 'none', textDecoration: 'none' }}
-                  _focus={{ outline: 'none' }}
-                >
-                  <Text
-                    cursor="pointer"
-                    color="blueLight"
-                    py={1}
-                    fontWeight="bold"
+          }) => {
+            const image = item.enclosures[0].url;
+            const resizedImage = image.replace(/\/h_[0-9]{2,}/gi, '/h_250'); // resize image to 250px height
+
+            return (
+              <Box
+                key={item.title}
+                role="group"
+                position="relative"
+                mt={4}
+                backgroundColor="blackAlpha.500"
+                borderRadius="md"
+                overflow="hidden"
+              >
+                <Box position="relative" zIndex={5} p={6}>
+                  <Heading
+                    size="xs"
+                    color="white"
+                    fontWeight="normal"
+                    pb={4}
+                    transition="all 0.2s ease-out"
+                    _groupHover={{ transform: 'translateY(-20px)', opacity: 0 }}
                   >
-                    Read Here
-                  </Text>
-                </Link>
-              </Box>
-              {item.enclosures &&
-                item.enclosures.length > 0 &&
-                item.enclosures[0].type === 'image/jpeg' && (
-                  <Box
-                    position="absolute"
-                    inset={0}
-                    width="full"
-                    height="full"
-                    bg="landingDarkGlass"
-                    bgImg={`url(${item.enclosures[0].url})`}
-                    bgSize="cover"
-                    opacity={0.2}
-                    zIndex={0}
+                    {item.title}
+                  </Heading>
+                  <Text
+                    dangerouslySetInnerHTML={{ __html: item.description }}
+                    transition="all 0.2s ease-out"
+                    _groupHover={{ transform: 'translateY(20px)', opacity: 0 }}
                   />
-                )}
-            </Box>
-          ),
+                  <Link
+                    display="inline-flex"
+                    href={item.link}
+                    px={2}
+                    _hover={{ bg: 'landingDarkGlass', textDecoration: 'none' }}
+                    _focus={{ outline: 'none' }}
+                    _groupHover={{
+                      bg: 'landingDarkGlass',
+                      textDecoration: 'none',
+                    }}
+                    borderRadius="md"
+                  >
+                    <Text
+                      cursor="pointer"
+                      color="blueLight"
+                      py={1}
+                      fontWeight="bold"
+                    >
+                      Read Here
+                    </Text>
+                  </Link>
+                </Box>
+                {item.enclosures &&
+                  item.enclosures.length > 0 &&
+                  item.enclosures[0].type === 'image/jpeg' && (
+                    <Box
+                      position="absolute"
+                      inset={0}
+                      width="full"
+                      height="full"
+                      opacity={0.2}
+                      zIndex={0}
+                      transition="opacity 0.3s ease-out"
+                      _groupHover={{ opacity: 0.9 }}
+                      sx={{
+                        '&::after': {
+                          content: '""',
+                          position: 'absolute',
+                          display: 'block',
+                          width: '100%',
+                          height: '100%',
+                          inset: 0,
+                          zIndex: 2,
+                          borderRadius: 'md',
+                          transition: 'all 0.2s',
+                          _groupHover: {
+                            boxShadow: '0 0 50px rgba(0, 0, 0, 0.9) inset',
+                          },
+                        },
+                      }}
+                    >
+                      <Image
+                        src={resizedImage}
+                        alt={item.title}
+                        width="full"
+                        height="full"
+                        objectFit="cover"
+                        opacity={0.2}
+                        transition="opacity 0.3s ease-out"
+                        _groupHover={{ opacity: 1 }}
+                        loading="lazy"
+                        zIndex={0}
+                      />
+                    </Box>
+                  )}
+              </Box>
+            );
+          },
         )
       ) : (
         <>

--- a/packages/web/components/Dashboard/LatestContentTabs/Watch.tsx
+++ b/packages/web/components/Dashboard/LatestContentTabs/Watch.tsx
@@ -71,7 +71,7 @@ export const Watch: React.FC = () => {
     }
   }, [loading, maxPages, nextPageToken, onScreen, page]);
   return (
-    <Box px={2}>
+    <Box px={2} pl={0}>
       {loading ? (
         <LoadingState />
       ) : (


### PR DESCRIPTION
## Overview

**What features/fixes does this PR include?**
Adds images for the newsletter posts in 'Latest content' and tweaks the guttering on the tablists to bring them inline with other blocks. 

**Please provide the GitHub issue number**

Closes #1354 

## Follow up Improvement Ideas

- [ ] please list any improvement/ideas

## Implementation

**Describe technical (nontrivial / non-obvious) parts of your code**

**Side effects**
I was concerned that the extra images being pulled in would be heavy on the bandwidth but found I could replace part of the substack image URL and get a smaller image back, so all images are optimised (<200kb mostly) before lazy loading to the page.  

## Assets
![image](https://user-images.githubusercontent.com/780350/194684352-84de6c4c-17eb-48b0-ae9e-614252e32a14.png)
![image](https://user-images.githubusercontent.com/780350/194684364-ce14e1dc-8b41-4224-82f8-5afdd2ea41ab.png)


