### PR TITLE
remove undeploy step

### DIFF
--- a/.github/workflows/gcp-deploy-frontend.yaml
+++ b/.github/workflows/gcp-deploy-frontend.yaml
@@ -106,42 +106,6 @@ jobs:
           echo "::set-output name=FRONTEND_TAG::\
           ${{steps.second.outputs.DOCKER_PATH}}/frontend:${{github.ref_name}}"
 
-  undeploy-frontend:
-    name: Undeploy Frontend
-    runs-on: ubuntu-latest
-    needs: [env]
-
-    steps:
-      - name: Set Up gcloud CLI
-        uses: google-github-actions/setup-gcloud@v0.6.0
-        with:
-          project_id: ${{needs.env.outputs.PROJECT_ID}}
-          service_account_key: ${{secrets.GCP_SA_KEY}}
-          export_default_credentials: true
-
-      - name: "Delete Service: ${{needs.env.outputs.FRONTEND_SERVICE}}"
-        continue-on-error: true
-        run: |
-          gcloud -q run services delete ${{needs.env.outputs.FRONTEND_SERVICE}} \
-            --region ${{needs.env.outputs.CLOUDRUN_REGION}}
-
-  delete-frontend:
-    name: Delete Frontend Container Image
-    runs-on: ubuntu-latest
-    needs: [env]
-
-    steps:
-      - name: Set Up gcloud CLI
-        uses: google-github-actions/setup-gcloud@v0.6.0
-        with:
-          project_id: ${{needs.env.outputs.PROJECT_ID}}
-          service_account_key: ${{secrets.GCP_SA_KEY}}
-          export_default_credentials: true
-
-      - name: "Delete Container Image: ${{needs.env.outputs.FRONTEND_TAG}}"
-        continue-on-error: true
-        run: gcloud -q artifacts docker images delete ${{needs.env.outputs.FRONTEND_TAG}}
-
   build-frontend:
     name: Build Frontend Container Image
     runs-on: ubuntu-latest


### PR DESCRIPTION
## Overview
fixes #1258 by removing the undeploy steps. this works because deploying to an existing instance just updates and and automatically reroutes traffic to the new revision with zero downtime

## Follow up Improvement Ideas
as it is, unused container images would start piling up since we cant just remove the old one now since it wont have a tag anymore. this would require some extra logic to find out the hash of the old image before building the new one and and deleting the old image by that hash after the new one got deployed