### PR TITLE
Dynamically calculate patron league amounts for /join/patrons page

### DIFF
--- a/packages/backend/src/handlers/remote-schemas/resolvers/seedGraph/queries.ts
+++ b/packages/backend/src/handlers/remote-schemas/resolvers/seedGraph/queries.ts
@@ -15,7 +15,11 @@ export const GetTopPSeedHoldersQuery = gql`
     userTokens(
       orderBy: pSeedBalance
       orderDirection: desc
-      where: { pSeedBalance_gt: "0" }
+      where: {
+        pSeedBalance_gt: "0"
+        # filter out this contract address
+        address_neq: "0xbaf60086da36033b458b892e2432958e219f4ed6"
+      }
       first: $limit
     ) {
       id

--- a/packages/backend/src/handlers/remote-schemas/resolvers/seedGraph/queries.ts
+++ b/packages/backend/src/handlers/remote-schemas/resolvers/seedGraph/queries.ts
@@ -1,4 +1,4 @@
-import { gql } from 'graphql-request/dist';
+import { gql } from 'graphql-request';
 
 export const GetTokenBalances = gql`
   query GetTokenBalances($address: ID!) {
@@ -18,7 +18,7 @@ export const GetTopPSeedHoldersQuery = gql`
       where: {
         pSeedBalance_gt: "0"
         # filter out this contract address
-        address_neq: "0xbaf60086da36033b458b892e2432958e219f4ed6"
+        address_not: "0xbaf60086da36033b458b892e2432958e219f4ed6"
       }
       first: $limit
     ) {

--- a/packages/utils/src/constants.ts
+++ b/packages/utils/src/constants.ts
@@ -22,5 +22,5 @@ export const IPFS_LINK_PATTERN =
   'https://{v1cid}.ipfs.dweb.link/{path}';
 
 export const PSEED_ADDRESS = '0x8a8fcd351ed553fc75aecbc566a32f94471f302e';
-export const PSEED_CONTRACT_DIVISOR = 1000000000000000000.0;
+export const PSEED_DECIMALS = 18;
 export const PSEED_FOR_QUEST = 100;

--- a/packages/utils/src/constants.ts
+++ b/packages/utils/src/constants.ts
@@ -22,5 +22,5 @@ export const IPFS_LINK_PATTERN =
   'https://{v1cid}.ipfs.dweb.link/{path}';
 
 export const PSEED_ADDRESS = '0x8a8fcd351ed553fc75aecbc566a32f94471f302e';
-
+export const PSEED_CONTRACT_DIVISOR = 1000000000000000000.0;
 export const PSEED_FOR_QUEST = 100;

--- a/packages/web/components/MegaMenu/XPSeedsBalance.tsx
+++ b/packages/web/components/MegaMenu/XPSeedsBalance.tsx
@@ -1,5 +1,5 @@
 import { Flex, HStack, Image, MetaTheme, Text, Tooltip } from '@metafam/ds';
-import { numbers } from '@metafam/utils';
+import { Constants, numbers } from '@metafam/utils';
 import SeedMarket from 'assets/seed-icon.svg';
 import XPStar from 'assets/xp-star.svg';
 import { usePSeedBalance } from 'lib/hooks/balances';
@@ -69,7 +69,7 @@ export const XPSeedsBalance: React.FC<Props> = ({ totalXP }) => {
             fontWeight="bold"
           >
             {parseInt(
-              amountToDecimal(pSeedBalance || '0', 18),
+              amountToDecimal(pSeedBalance || '0', Constants.PSEED_DECIMALS),
               10,
             ).toLocaleString()}
           </Text>

--- a/packages/web/components/Patron/Join/PerksGrid.tsx
+++ b/packages/web/components/Patron/Join/PerksGrid.tsx
@@ -181,8 +181,8 @@ const PerksGrid: React.FC<Props> = ({ pSeedPrice, pSeedHolders }) => (
         />
 
         <Flex p={8} width="100%" flexDirection="row" flexWrap="wrap">
-          {AllPatronsList.map((text: string) => (
-            <LeagueCardItem text={text} />
+          {AllPatronsList.map((text: string, index) => (
+            <LeagueCardItem key={index} text={text} />
           ))}
         </Flex>
       </VStack>
@@ -211,8 +211,8 @@ const PerksGrid: React.FC<Props> = ({ pSeedPrice, pSeedHolders }) => (
         />
         <Box p={8} width="100%" color="white">
           <Flex width="100%" flexDirection="row" flexWrap="wrap">
-            {BronzeLeagueList.map((text: string) => (
-              <LeagueCardItem text={text} />
+            {BronzeLeagueList.map((text: string, index) => (
+              <LeagueCardItem key={index} text={text} />
             ))}
           </Flex>
         </Box>
@@ -244,8 +244,8 @@ const PerksGrid: React.FC<Props> = ({ pSeedPrice, pSeedHolders }) => (
         <Box p={8} width="100%" color="white">
           <List textAlign="left">
             <Flex width="100%" flexDirection="row" flexWrap="wrap">
-              {SilverLeagueList.map((text: string) => (
-                <LeagueCardItem text={text} />
+              {SilverLeagueList.map((text: string, index) => (
+                <LeagueCardItem key={index} text={text} />
               ))}
             </Flex>
           </List>
@@ -277,8 +277,8 @@ const PerksGrid: React.FC<Props> = ({ pSeedPrice, pSeedHolders }) => (
 
         <Box p={8} width="100%" color="white">
           <Flex width="100%" flexDirection="row" flexWrap="wrap">
-            {GoldenLeagueList.map((text: string) => (
-              <LeagueCardItem text={text} />
+            {GoldenLeagueList.map((text: string, index) => (
+              <LeagueCardItem key={index} text={text} />
             ))}
           </Flex>
         </Box>
@@ -310,8 +310,8 @@ const PerksGrid: React.FC<Props> = ({ pSeedPrice, pSeedHolders }) => (
 
         <Box p={8} width="100%" color="white">
           <Flex width="100%" flexDirection="row" flexWrap="wrap">
-            {PlatinumLeagueList.map((text: string) => (
-              <LeagueCardItem text={text} />
+            {PlatinumLeagueList.map((text: string, index) => (
+              <LeagueCardItem key={index} text={text} />
             ))}
           </Flex>
         </Box>
@@ -342,8 +342,8 @@ const PerksGrid: React.FC<Props> = ({ pSeedPrice, pSeedHolders }) => (
 
         <Box p={8} width="100%" color="white">
           <Flex width="100%" flexDirection="row" flexWrap="wrap">
-            {DiamondLeagueList.map((text: string) => (
-              <LeagueCardItem text={text} />
+            {DiamondLeagueList.map((text: string, index) => (
+              <LeagueCardItem key={index} text={text} />
             ))}
           </Flex>
         </Box>
@@ -402,8 +402,8 @@ const PerksGrid: React.FC<Props> = ({ pSeedPrice, pSeedHolders }) => (
 
         <Box p={8} width="100%" color="white">
           <Flex width="100%" flexDirection="row" flexWrap="wrap">
-            {No1PatronList.map((text: string) => (
-              <LeagueCardItem text={text} />
+            {No1PatronList.map((text: string, index) => (
+              <LeagueCardItem key={index} text={text} />
             ))}
           </Flex>
         </Box>

--- a/packages/web/components/Patron/Join/PerksGrid.tsx
+++ b/packages/web/components/Patron/Join/PerksGrid.tsx
@@ -1,12 +1,14 @@
 import { Box, Container, Flex, Heading, List, Text, VStack } from '@metafam/ds';
+import { Maybe } from '@metafam/utils';
 import BlueArrow from 'assets/patron/blue-arrow.png';
 import { PlayerRank_Enum, TokenBalancesFragment } from 'graphql/autogen/types';
 import {
   getLeagueCount,
   getLeagueCutoff,
-  getPatronHoldingsUsd,
+  getPatronPSeedHoldings,
   MIN_PATRON_PSEEDS,
   NUM_PATRONS,
+  PATRON_RANKS,
 } from 'utils/patronHelpers';
 
 import { LeagueCardItem } from './LeagueCardItem';
@@ -92,324 +94,344 @@ const LeftArrowStyle = {
 type PerksProps = {
   title: string;
   count: number | string;
-  amount: number;
+  pSeeds: number;
+  amountUsd: Maybe<number>;
 };
 
-const PerksHeader = ({ title, count, amount }: PerksProps) => (
-  <Flex
-    direction="row"
-    justify="space-between"
-    bg="purpleBoxLight"
-    p="4"
-    roundedTop="lg"
-    width={'100%'}
-  >
-    <Text color="white" fontWeight="bold">
-      {title}
-    </Text>
-    <Text color="landing450" fontSize="sm" fontWeight="bold">
-      {typeof count === 'number'
-        ? `(total of ${Number(count).toLocaleString()})`
-        : `(${count})`}
-    </Text>
-    <Text color="white" fontSize="md">
-      {`$${Number(amount).toLocaleString(undefined, {
+const PerksHeader = ({ title, count, pSeeds, amountUsd }: PerksProps) => {
+  const amountDisplay = amountUsd
+    ? `$${Number(amountUsd).toLocaleString(undefined, {
         maximumFractionDigits: 2,
-      })}`}
-    </Text>
-  </Flex>
-);
+      })}`
+    : `${pSeeds} pSEEDs`;
+  return (
+    <Flex
+      direction="row"
+      justify="space-between"
+      bg="purpleBoxLight"
+      p="4"
+      roundedTop="lg"
+      width={'100%'}
+    >
+      <Text color="white" fontWeight="bold">
+        {title}
+      </Text>
+      <Text color="landing450" fontSize="sm" fontWeight="bold">
+        {typeof count === 'number'
+          ? `(total of ${Number(count).toLocaleString()})`
+          : `(${count})`}
+      </Text>
+      <Text color="white" fontSize="md">
+        {amountDisplay}
+      </Text>
+    </Flex>
+  );
+};
 
 type Props = {
-  pSeedPrice: number;
+  pSeedPrice: Maybe<number>;
   pSeedHolders: TokenBalancesFragment[];
 };
 
-const PerksGrid: React.FC<Props> = ({ pSeedPrice, pSeedHolders }) => (
-  <Container w="100%" maxW="6xl" my={12}>
-    <Box
-      width={{ base: '100%', md: '50%' }}
-      float={{ base: 'none', md: 'left' }}
-    >
-      <VStack
-        spacing={0}
-        minH="5rem"
-        borderRadius={8}
-        mb={{ base: 0, md: '1em' }} // the arrow on the next Box arrow makes the margin at base breakpoint
+const PerksGrid: React.FC<Props> = ({ pSeedPrice, pSeedHolders }) => {
+  const leaguePSeedsByRank: { [rank: string]: number } = {};
+  PATRON_RANKS.forEach((rankEnum) => {
+    leaguePSeedsByRank[`${rankEnum}`] = getLeagueCutoff(rankEnum, pSeedHolders);
+  });
+  const topHodlerPSeeds = getPatronPSeedHoldings(pSeedHolders[0]);
+
+  return (
+    <Container w="100%" maxW="6xl" my={12}>
+      <Box
+        width={{ base: '100%', md: '50%' }}
+        float={{ base: 'none', md: 'left' }}
       >
-        <Box bg="whiteAlpha.200" borderRadius={8} px={8} py={8}>
-          <Heading
-            as="h2"
-            color="white"
-            fontFamily="mono"
-            fontWeight={700}
-            mb={[4, 4, 4, 12]}
-          >
-            Ranked Leagues &amp; Perks
-          </Heading>
+        <VStack
+          spacing={0}
+          minH="5rem"
+          borderRadius={8}
+          mb={{ base: 0, md: '1em' }} // the arrow on the next Box arrow makes the margin at base breakpoint
+        >
+          <Box bg="whiteAlpha.200" borderRadius={8} px={8} py={8}>
+            <Heading
+              as="h2"
+              color="white"
+              fontFamily="mono"
+              fontWeight={700}
+              mb={[4, 4, 4, 12]}
+            >
+              Ranked Leagues &amp; Perks
+            </Heading>
 
-          <Text as="p" fontWeight="700" color="white" mb={4}>
-            Becoming a patron also comes with some perks!
-          </Text>
-          <Text as="p" color="white">
-            Do note the total number of Patrons in Phase I is limited to 150;
-            the rank requirements are subject to change based on top 150 pSeed
-            hodlors &amp; most perks (besides seasonal) will only be unlocked in
-            the transition to Phase II - set for Q3 2023.
-          </Text>
-        </Box>
-      </VStack>
-    </Box>
+            <Text as="p" fontWeight="700" color="white" mb={4}>
+              Becoming a patron also comes with some perks!
+            </Text>
+            <Text as="p" color="white">
+              Do note the total number of Patrons in Phase I is limited to 150;
+              the rank requirements are subject to change based on top 150 pSeed
+              hodlors &amp; most perks (besides seasonal) will only be unlocked
+              in the transition to Phase II - set for Q3 2023.
+            </Text>
+          </Box>
+        </VStack>
+      </Box>
 
-    <Box
-      width={{ base: '100%', md: '50%' }}
-      float={{ base: 'none', md: 'right' }}
-      _before={RightArrowStyle}
-      mt={{ base: '0', md: '4.5em' }}
-    >
-      <VStack
-        spacing={0}
-        borderRadius={8}
-        minH="12rem"
-        bg="whiteAlpha.200"
-        mb={{ base: 0, md: '1em' }} // the arrow on the next Box arrow makes the margin at base breakpoint
+      <Box
+        width={{ base: '100%', md: '50%' }}
+        float={{ base: 'none', md: 'right' }}
+        _before={RightArrowStyle}
+        mt={{ base: '0', md: '4.5em' }}
       >
-        <PerksHeader
-          title={'All Patrons'}
-          count={NUM_PATRONS}
-          amount={MIN_PATRON_PSEEDS * pSeedPrice}
-        />
+        <VStack
+          spacing={0}
+          borderRadius={8}
+          minH="12rem"
+          bg="whiteAlpha.200"
+          mb={{ base: 0, md: '1em' }} // the arrow on the next Box arrow makes the margin at base breakpoint
+        >
+          <PerksHeader
+            title={'All Patrons'}
+            count={NUM_PATRONS}
+            pSeeds={MIN_PATRON_PSEEDS}
+            amountUsd={pSeedPrice ? MIN_PATRON_PSEEDS * pSeedPrice : null}
+          />
 
-        <Flex p={8} width="100%" flexDirection="row" flexWrap="wrap">
-          {AllPatronsList.map((text: string, index) => (
-            <LeagueCardItem key={index} text={text} />
-          ))}
-        </Flex>
-      </VStack>
-    </Box>
-
-    <Box
-      width={{ base: '100%', md: '50%' }}
-      float={{ base: 'none', md: 'left' }}
-      _before={LeftArrowStyle}
-    >
-      <VStack
-        bg="whiteAlpha.200"
-        spacing={0}
-        borderRadius={8}
-        minH="10rem"
-        mb={{ base: 0, md: '1em' }} // the arrow on the next Box arrow makes the margin at base breakpoint
-      >
-        <PerksHeader
-          title={'Bronze League'}
-          count={getLeagueCount(PlayerRank_Enum.Bronze)}
-          amount={getLeagueCutoff(
-            PlayerRank_Enum.Bronze,
-            pSeedHolders,
-            pSeedPrice,
-          )}
-        />
-        <Box p={8} width="100%" color="white">
-          <Flex width="100%" flexDirection="row" flexWrap="wrap">
-            {BronzeLeagueList.map((text: string, index) => (
+          <Flex p={8} width="100%" flexDirection="row" flexWrap="wrap">
+            {AllPatronsList.map((text: string, index) => (
               <LeagueCardItem key={index} text={text} />
             ))}
           </Flex>
-        </Box>
-      </VStack>
-    </Box>
+        </VStack>
+      </Box>
 
-    <Box
-      width={{ base: '100%', md: '50%' }}
-      float={{ base: 'none', md: 'right' }}
-      _before={RightArrowStyle}
-    >
-      <VStack
-        spacing={0}
-        borderRadius={8}
-        minH="8rem"
-        bg="whiteAlpha.200"
-        mb={{ base: 0, md: '1em' }} // the arrow on the next Box arrow makes the margin at base breakpoint
+      <Box
+        width={{ base: '100%', md: '50%' }}
+        float={{ base: 'none', md: 'left' }}
+        _before={LeftArrowStyle}
       >
-        <PerksHeader
-          title={'Silver League'}
-          count={getLeagueCount(PlayerRank_Enum.Silver)}
-          amount={getLeagueCutoff(
-            PlayerRank_Enum.Silver,
-            pSeedHolders,
-            pSeedPrice,
-          )}
-        />
-
-        <Box p={8} width="100%" color="white">
-          <List textAlign="left">
+        <VStack
+          bg="whiteAlpha.200"
+          spacing={0}
+          borderRadius={8}
+          minH="10rem"
+          mb={{ base: 0, md: '1em' }} // the arrow on the next Box arrow makes the margin at base breakpoint
+        >
+          <PerksHeader
+            title={'Bronze League'}
+            count={getLeagueCount(PlayerRank_Enum.Bronze)}
+            pSeeds={leaguePSeedsByRank[PlayerRank_Enum.Bronze]}
+            amountUsd={
+              pSeedPrice
+                ? leaguePSeedsByRank[PlayerRank_Enum.Bronze] * pSeedPrice
+                : null
+            }
+          />
+          <Box p={8} width="100%" color="white">
             <Flex width="100%" flexDirection="row" flexWrap="wrap">
-              {SilverLeagueList.map((text: string, index) => (
+              {BronzeLeagueList.map((text: string, index) => (
                 <LeagueCardItem key={index} text={text} />
               ))}
             </Flex>
-          </List>
-        </Box>
-      </VStack>
-    </Box>
+          </Box>
+        </VStack>
+      </Box>
 
-    <Box
-      width={{ base: '100%', md: '50%' }}
-      float={{ base: 'none', md: 'left' }}
-      _before={LeftArrowStyle}
-    >
-      <VStack
-        spacing={0}
-        borderRadius={8}
-        minH="8rem"
-        bg="whiteAlpha.200"
-        mb={{ base: 0, md: '1em' }} // the arrow on the next Box arrow makes the margin at base breakpoint
+      <Box
+        width={{ base: '100%', md: '50%' }}
+        float={{ base: 'none', md: 'right' }}
+        _before={RightArrowStyle}
       >
-        <PerksHeader
-          title={'Gold League'}
-          count={getLeagueCount(PlayerRank_Enum.Gold)}
-          amount={getLeagueCutoff(
-            PlayerRank_Enum.Gold,
-            pSeedHolders,
-            pSeedPrice,
-          )}
-        />
-
-        <Box p={8} width="100%" color="white">
-          <Flex width="100%" flexDirection="row" flexWrap="wrap">
-            {GoldenLeagueList.map((text: string, index) => (
-              <LeagueCardItem key={index} text={text} />
-            ))}
-          </Flex>
-        </Box>
-      </VStack>
-    </Box>
-
-    <Box
-      width={{ base: '100%', md: '50%' }}
-      float={{ base: 'none', md: 'right' }}
-      _before={RightArrowStyle}
-    >
-      <VStack
-        spacing={0}
-        borderRadius={8}
-        minH="5rem"
-        bg="whiteAlpha.200"
-        mb={{ base: 0, md: '1em' }} // the arrow on the next Box arrow makes the margin at base breakpoint
-      >
-        <PerksHeader
-          title={'Platinum League'}
-          count={getLeagueCount(PlayerRank_Enum.Platinum)}
-          amount={getLeagueCutoff(
-            PlayerRank_Enum.Platinum,
-            pSeedHolders,
-            pSeedPrice,
-          )}
-          // amount={3631}
-        />
-
-        <Box p={8} width="100%" color="white">
-          <Flex width="100%" flexDirection="row" flexWrap="wrap">
-            {PlatinumLeagueList.map((text: string, index) => (
-              <LeagueCardItem key={index} text={text} />
-            ))}
-          </Flex>
-        </Box>
-      </VStack>
-    </Box>
-
-    <Box
-      width={{ base: '100%', md: '50%' }}
-      float={{ base: 'none', md: 'left' }}
-      _before={LeftArrowStyle}
-    >
-      <VStack
-        spacing={0}
-        borderRadius={8}
-        minH="6rem"
-        bg="whiteAlpha.200"
-        mb={{ base: 0, md: '1em' }} // the arrow on the next Box arrow makes the margin at base breakpoint
-      >
-        <PerksHeader
-          title={'Diamond League'}
-          count={getLeagueCount(PlayerRank_Enum.Diamond)}
-          amount={getLeagueCutoff(
-            PlayerRank_Enum.Diamond,
-            pSeedHolders,
-            pSeedPrice,
-          )}
-        />
-
-        <Box p={8} width="100%" color="white">
-          <Flex width="100%" flexDirection="row" flexWrap="wrap">
-            {DiamondLeagueList.map((text: string, index) => (
-              <LeagueCardItem key={index} text={text} />
-            ))}
-          </Flex>
-        </Box>
-      </VStack>
-    </Box>
-
-    <Box
-      width={{ base: '100%', md: '50%' }}
-      float={{ base: 'none', md: 'right' }}
-      _before={RightArrowStyle}
-      _after={{
-        content: '""',
-        background: `url(${BlueArrow})`,
-        height: '1.75em',
-        width: '1.625em',
-        transform: 'rotate(90deg)',
-        display: 'block',
-        left: { base: 'calc(50% - 0.8125em)', md: '10.625em' },
-        top: '0px',
-        position: 'relative',
-      }}
-    >
-      <VStack spacing={0} minH="1rem" align="left" isInline>
-        <Box
-          mx={{ base: 'auto', md: '0' }}
-          bg="whiteAlpha.200"
+        <VStack
+          spacing={0}
           borderRadius={8}
+          minH="8rem"
+          bg="whiteAlpha.200"
+          mb={{ base: 0, md: '1em' }} // the arrow on the next Box arrow makes the margin at base breakpoint
         >
-          <Text
-            as="p"
-            textAlign="center"
-            fontWeight="700"
-            color="white"
+          <PerksHeader
+            title={'Silver League'}
+            count={getLeagueCount(PlayerRank_Enum.Silver)}
+            pSeeds={leaguePSeedsByRank[PlayerRank_Enum.Silver]}
+            amountUsd={
+              pSeedPrice
+                ? leaguePSeedsByRank[PlayerRank_Enum.Silver] * pSeedPrice
+                : null
+            }
+          />
+
+          <Box p={8} width="100%" color="white">
+            <List textAlign="left">
+              <Flex width="100%" flexDirection="row" flexWrap="wrap">
+                {SilverLeagueList.map((text: string, index) => (
+                  <LeagueCardItem key={index} text={text} />
+                ))}
+              </Flex>
+            </List>
+          </Box>
+        </VStack>
+      </Box>
+
+      <Box
+        width={{ base: '100%', md: '50%' }}
+        float={{ base: 'none', md: 'left' }}
+        _before={LeftArrowStyle}
+      >
+        <VStack
+          spacing={0}
+          borderRadius={8}
+          minH="8rem"
+          bg="whiteAlpha.200"
+          mb={{ base: 0, md: '1em' }} // the arrow on the next Box arrow makes the margin at base breakpoint
+        >
+          <PerksHeader
+            title={'Gold League'}
+            count={getLeagueCount(PlayerRank_Enum.Gold)}
+            pSeeds={leaguePSeedsByRank[PlayerRank_Enum.Gold]}
+            amountUsd={
+              pSeedPrice
+                ? leaguePSeedsByRank[PlayerRank_Enum.Gold] * pSeedPrice
+                : null
+            }
+          />
+
+          <Box p={8} width="100%" color="white">
+            <Flex width="100%" flexDirection="row" flexWrap="wrap">
+              {GoldenLeagueList.map((text: string, index) => (
+                <LeagueCardItem key={index} text={text} />
+              ))}
+            </Flex>
+          </Box>
+        </VStack>
+      </Box>
+
+      <Box
+        width={{ base: '100%', md: '50%' }}
+        float={{ base: 'none', md: 'right' }}
+        _before={RightArrowStyle}
+      >
+        <VStack
+          spacing={0}
+          borderRadius={8}
+          minH="5rem"
+          bg="whiteAlpha.200"
+          mb={{ base: 0, md: '1em' }} // the arrow on the next Box arrow makes the margin at base breakpoint
+        >
+          <PerksHeader
+            title={'Platinum League'}
+            count={getLeagueCount(PlayerRank_Enum.Platinum)}
+            pSeeds={leaguePSeedsByRank[PlayerRank_Enum.Platinum]}
+            amountUsd={
+              pSeedPrice
+                ? leaguePSeedsByRank[PlayerRank_Enum.Platinum] * pSeedPrice
+                : null
+            }
+          />
+
+          <Box p={8} width="100%" color="white">
+            <Flex width="100%" flexDirection="row" flexWrap="wrap">
+              {PlatinumLeagueList.map((text: string, index) => (
+                <LeagueCardItem key={index} text={text} />
+              ))}
+            </Flex>
+          </Box>
+        </VStack>
+      </Box>
+
+      <Box
+        width={{ base: '100%', md: '50%' }}
+        float={{ base: 'none', md: 'left' }}
+        _before={LeftArrowStyle}
+      >
+        <VStack
+          spacing={0}
+          borderRadius={8}
+          minH="6rem"
+          bg="whiteAlpha.200"
+          mb={{ base: 0, md: '1em' }} // the arrow on the next Box arrow makes the margin at base breakpoint
+        >
+          <PerksHeader
+            title={'Diamond League'}
+            count={getLeagueCount(PlayerRank_Enum.Diamond)}
+            pSeeds={leaguePSeedsByRank[PlayerRank_Enum.Diamond]}
+            amountUsd={
+              pSeedPrice
+                ? leaguePSeedsByRank[PlayerRank_Enum.Diamond] * pSeedPrice
+                : null
+            }
+          />
+
+          <Box p={8} width="100%" color="white">
+            <Flex width="100%" flexDirection="row" flexWrap="wrap">
+              {DiamondLeagueList.map((text: string, index) => (
+                <LeagueCardItem key={index} text={text} />
+              ))}
+            </Flex>
+          </Box>
+        </VStack>
+      </Box>
+
+      <Box
+        width={{ base: '100%', md: '50%' }}
+        float={{ base: 'none', md: 'right' }}
+        _before={RightArrowStyle}
+        _after={{
+          content: '""',
+          background: `url(${BlueArrow})`,
+          height: '1.75em',
+          width: '1.625em',
+          transform: 'rotate(90deg)',
+          display: 'block',
+          left: { base: 'calc(50% - 0.8125em)', md: '10.625em' },
+          top: '0px',
+          position: 'relative',
+        }}
+      >
+        <VStack spacing={0} minH="1rem" align="left" isInline>
+          <Box
+            mx={{ base: 'auto', md: '0' }}
+            bg="whiteAlpha.200"
             borderRadius={8}
-            px={12}
-            py={4}
           >
-            &hellip;aaaand for the one &amp; only 👇
-          </Text>
-        </Box>
-      </VStack>
-    </Box>
+            <Text
+              as="p"
+              textAlign="center"
+              fontWeight="700"
+              color="white"
+              borderRadius={8}
+              px={12}
+              py={4}
+            >
+              &hellip;aaaand for the one &amp; only 👇
+            </Text>
+          </Box>
+        </VStack>
+      </Box>
 
-    <Box
-      minH="5rem"
-      width={{ base: '100%', md: '50%' }}
-      mx={{ base: 0, md: 'auto' }}
-      sx={{ clear: 'both' }}
-    >
-      <VStack spacing={0} borderRadius={8} minH="6rem" bg="whiteAlpha.200">
-        <PerksHeader
-          title={'No. 1 Patron of MetaGame’s Seed Phase'}
-          count={'unique'}
-          amount={getPatronHoldingsUsd(pSeedHolders?.[0], pSeedPrice)}
-        />
+      <Box
+        minH="5rem"
+        width={{ base: '100%', md: '50%' }}
+        mx={{ base: 0, md: 'auto' }}
+        sx={{ clear: 'both' }}
+      >
+        <VStack spacing={0} borderRadius={8} minH="6rem" bg="whiteAlpha.200">
+          <PerksHeader
+            title={'No. 1 Patron of MetaGame’s Seed Phase'}
+            count={'unique'}
+            pSeeds={topHodlerPSeeds}
+            amountUsd={pSeedPrice != null ? topHodlerPSeeds * pSeedPrice : null}
+          />
 
-        <Box p={8} width="100%" color="white">
-          <Flex width="100%" flexDirection="row" flexWrap="wrap">
-            {No1PatronList.map((text: string, index) => (
-              <LeagueCardItem key={index} text={text} />
-            ))}
-          </Flex>
-        </Box>
-      </VStack>
-    </Box>
-  </Container>
-);
+          <Box p={8} width="100%" color="white">
+            <Flex width="100%" flexDirection="row" flexWrap="wrap">
+              {No1PatronList.map((text: string, index) => (
+                <LeagueCardItem key={index} text={text} />
+              ))}
+            </Flex>
+          </Box>
+        </VStack>
+      </Box>
+    </Container>
+  );
+};
 
 export default PerksGrid;

--- a/packages/web/components/Patron/Join/PerksGrid.tsx
+++ b/packages/web/components/Patron/Join/PerksGrid.tsx
@@ -1,5 +1,13 @@
 import { Box, Container, Flex, Heading, List, Text, VStack } from '@metafam/ds';
 import BlueArrow from 'assets/patron/blue-arrow.png';
+import { PlayerRank_Enum, TokenBalancesFragment } from 'graphql/autogen/types';
+import {
+  getLeagueCount,
+  getLeagueCutoff,
+  getPatronHoldingsUsd,
+  MIN_PATRON_PSEEDS,
+  NUM_PATRONS,
+} from 'utils/patronHelpers';
 
 import { LeagueCardItem } from './LeagueCardItem';
 
@@ -105,12 +113,19 @@ const PerksHeader = ({ title, count, amount }: PerksProps) => (
         : `(${count})`}
     </Text>
     <Text color="white" fontSize="md">
-      {`$${Number(amount).toLocaleString()}`}
+      {`$${Number(amount).toLocaleString(undefined, {
+        maximumFractionDigits: 2,
+      })}`}
     </Text>
   </Flex>
 );
 
-const PerksGrid = () => (
+type Props = {
+  pSeedPrice: number;
+  pSeedHolders: TokenBalancesFragment[];
+};
+
+const PerksGrid: React.FC<Props> = ({ pSeedPrice, pSeedHolders }) => (
   <Container w="100%" maxW="6xl" my={12}>
     <Box
       width={{ base: '100%', md: '50%' }}
@@ -159,7 +174,11 @@ const PerksGrid = () => (
         bg="whiteAlpha.200"
         mb={{ base: 0, md: '1em' }} // the arrow on the next Box arrow makes the margin at base breakpoint
       >
-        <PerksHeader title={'All Patrons'} count={150} amount={101} />
+        <PerksHeader
+          title={'All Patrons'}
+          count={NUM_PATRONS}
+          amount={MIN_PATRON_PSEEDS * pSeedPrice}
+        />
 
         <Flex p={8} width="100%" flexDirection="row" flexWrap="wrap">
           {AllPatronsList.map((text: string) => (
@@ -181,7 +200,15 @@ const PerksGrid = () => (
         minH="10rem"
         mb={{ base: 0, md: '1em' }} // the arrow on the next Box arrow makes the margin at base breakpoint
       >
-        <PerksHeader title={'Bronze League'} count={21} amount={131} />
+        <PerksHeader
+          title={'Bronze League'}
+          count={getLeagueCount(PlayerRank_Enum.Bronze)}
+          amount={getLeagueCutoff(
+            PlayerRank_Enum.Bronze,
+            pSeedHolders,
+            pSeedPrice,
+          )}
+        />
         <Box p={8} width="100%" color="white">
           <Flex width="100%" flexDirection="row" flexWrap="wrap">
             {BronzeLeagueList.map((text: string) => (
@@ -204,7 +231,15 @@ const PerksGrid = () => (
         bg="whiteAlpha.200"
         mb={{ base: 0, md: '1em' }} // the arrow on the next Box arrow makes the margin at base breakpoint
       >
-        <PerksHeader title={'Silver League'} count={14} amount={177} />
+        <PerksHeader
+          title={'Silver League'}
+          count={getLeagueCount(PlayerRank_Enum.Silver)}
+          amount={getLeagueCutoff(
+            PlayerRank_Enum.Silver,
+            pSeedHolders,
+            pSeedPrice,
+          )}
+        />
 
         <Box p={8} width="100%" color="white">
           <List textAlign="left">
@@ -230,7 +265,15 @@ const PerksGrid = () => (
         bg="whiteAlpha.200"
         mb={{ base: 0, md: '1em' }} // the arrow on the next Box arrow makes the margin at base breakpoint
       >
-        <PerksHeader title={'Gold League'} count={7} amount={519} />
+        <PerksHeader
+          title={'Gold League'}
+          count={getLeagueCount(PlayerRank_Enum.Gold)}
+          amount={getLeagueCutoff(
+            PlayerRank_Enum.Gold,
+            pSeedHolders,
+            pSeedPrice,
+          )}
+        />
 
         <Box p={8} width="100%" color="white">
           <Flex width="100%" flexDirection="row" flexWrap="wrap">
@@ -254,7 +297,16 @@ const PerksGrid = () => (
         bg="whiteAlpha.200"
         mb={{ base: 0, md: '1em' }} // the arrow on the next Box arrow makes the margin at base breakpoint
       >
-        <PerksHeader title={'Platinum League'} count={7} amount={3631} />
+        <PerksHeader
+          title={'Platinum League'}
+          count={getLeagueCount(PlayerRank_Enum.Platinum)}
+          amount={getLeagueCutoff(
+            PlayerRank_Enum.Platinum,
+            pSeedHolders,
+            pSeedPrice,
+          )}
+          // amount={3631}
+        />
 
         <Box p={8} width="100%" color="white">
           <Flex width="100%" flexDirection="row" flexWrap="wrap">
@@ -278,7 +330,16 @@ const PerksGrid = () => (
         bg="whiteAlpha.200"
         mb={{ base: 0, md: '1em' }} // the arrow on the next Box arrow makes the margin at base breakpoint
       >
-        <PerksHeader title={'Diamond League'} count={7} amount={14049} />
+        <PerksHeader
+          title={'Diamond League'}
+          count={getLeagueCount(PlayerRank_Enum.Diamond)}
+          amount={getLeagueCutoff(
+            PlayerRank_Enum.Diamond,
+            pSeedHolders,
+            pSeedPrice,
+          )}
+          // amount={14049}
+        />
 
         <Box p={8} width="100%" color="white">
           <Flex width="100%" flexDirection="row" flexWrap="wrap">
@@ -337,7 +398,7 @@ const PerksGrid = () => (
         <PerksHeader
           title={'No. 1 Patron of MetaGame’s Seed Phase'}
           count={'unique'}
-          amount={21206}
+          amount={getPatronHoldingsUsd(pSeedHolders[0], pSeedPrice)}
         />
 
         <Box p={8} width="100%" color="white">

--- a/packages/web/components/Patron/Join/PerksGrid.tsx
+++ b/packages/web/components/Patron/Join/PerksGrid.tsx
@@ -1,4 +1,13 @@
-import { Box, Container, Flex, Heading, List, Text, VStack } from '@metafam/ds';
+import {
+  Box,
+  Container,
+  Flex,
+  Heading,
+  List,
+  Text,
+  Tooltip,
+  VStack,
+} from '@metafam/ds';
 import { Maybe } from '@metafam/utils';
 import BlueArrow from 'assets/patron/blue-arrow.png';
 import { PlayerRank_Enum, TokenBalancesFragment } from 'graphql/autogen/types';
@@ -99,11 +108,23 @@ type PerksProps = {
 };
 
 const PerksHeader = ({ title, count, pSeeds, amountUsd }: PerksProps) => {
-  const amountDisplay = amountUsd
+  const pSeedLabel = `${pSeeds.toLocaleString(undefined, {
+    maximumFractionDigits: 1,
+  })} pSEED`;
+  const amountLabel = amountUsd
     ? `$${Number(amountUsd).toLocaleString(undefined, {
+        minimumFractionDigits: 2,
         maximumFractionDigits: 2,
       })}`
-    : `${pSeeds} pSEEDs`;
+    : pSeedLabel;
+  let amountDisplay = (
+    <Text color="white" fontSize="md">
+      {amountLabel}
+    </Text>
+  );
+  if (amountUsd != null) {
+    amountDisplay = <Tooltip label={pSeedLabel}>{amountDisplay}</Tooltip>;
+  }
   return (
     <Flex
       direction="row"
@@ -111,19 +132,17 @@ const PerksHeader = ({ title, count, pSeeds, amountUsd }: PerksProps) => {
       bg="purpleBoxLight"
       p="4"
       roundedTop="lg"
-      width={'100%'}
+      width="100%"
     >
       <Text color="white" fontWeight="bold">
         {title}
       </Text>
       <Text color="landing450" fontSize="sm" fontWeight="bold">
         {typeof count === 'number'
-          ? `(total of ${Number(count).toLocaleString()})`
+          ? `(total of ${count.toLocaleString()})`
           : `(${count})`}
       </Text>
-      <Text color="white" fontSize="md">
-        {amountDisplay}
-      </Text>
+      {amountDisplay}
     </Flex>
   );
 };
@@ -136,7 +155,7 @@ type Props = {
 const PerksGrid: React.FC<Props> = ({ pSeedPrice, pSeedHolders }) => {
   const leaguePSeedsByRank: { [rank: string]: number } = {};
   PATRON_RANKS.forEach((rankEnum) => {
-    leaguePSeedsByRank[`${rankEnum}`] = getLeagueCutoff(rankEnum, pSeedHolders);
+    leaguePSeedsByRank[rankEnum] = getLeagueCutoff(rankEnum, pSeedHolders);
   });
   const topHodlerPSeeds = getPatronPSeedHoldings(pSeedHolders[0]);
 
@@ -167,10 +186,10 @@ const PerksGrid: React.FC<Props> = ({ pSeedPrice, pSeedHolders }) => {
               Becoming a patron also comes with some perks!
             </Text>
             <Text as="p" color="white">
-              Do note the total number of Patrons in Phase I is limited to 150;
-              the rank requirements are subject to change based on top 150 pSeed
-              hodlors &amp; most perks (besides seasonal) will only be unlocked
-              in the transition to Phase II - set for Q3 2023.
+              The total number of Patrons in Phase I is limited to 150. The rank
+              requirements are subject to change based on top 150 pSeed hodlors
+              &amp; most perks (besides seasonal) will only be unlocked in the
+              transition to Phase II — set for Q3 2023.
             </Text>
           </Box>
         </VStack>
@@ -180,7 +199,7 @@ const PerksGrid: React.FC<Props> = ({ pSeedPrice, pSeedHolders }) => {
         width={{ base: '100%', md: '50%' }}
         float={{ base: 'none', md: 'right' }}
         _before={RightArrowStyle}
-        mt={{ base: '0', md: '4.5em' }}
+        mt={{ base: 0, md: '4.5em' }}
       >
         <VStack
           spacing={0}
@@ -382,7 +401,7 @@ const PerksGrid: React.FC<Props> = ({ pSeedPrice, pSeedHolders }) => {
           transform: 'rotate(90deg)',
           display: 'block',
           left: { base: 'calc(50% - 0.8125em)', md: '10.625em' },
-          top: '0px',
+          top: 0,
           position: 'relative',
         }}
       >

--- a/packages/web/components/Patron/Join/PerksGrid.tsx
+++ b/packages/web/components/Patron/Join/PerksGrid.tsx
@@ -338,7 +338,6 @@ const PerksGrid: React.FC<Props> = ({ pSeedPrice, pSeedHolders }) => (
             pSeedHolders,
             pSeedPrice,
           )}
-          // amount={14049}
         />
 
         <Box p={8} width="100%" color="white">
@@ -398,7 +397,7 @@ const PerksGrid: React.FC<Props> = ({ pSeedPrice, pSeedHolders }) => (
         <PerksHeader
           title={'No. 1 Patron of MetaGame’s Seed Phase'}
           count={'unique'}
-          amount={getPatronHoldingsUsd(pSeedHolders[0], pSeedPrice)}
+          amount={getPatronHoldingsUsd(pSeedHolders?.[0], pSeedPrice)}
         />
 
         <Box p={8} width="100%" color="white">

--- a/packages/web/components/Patron/Join/RankedLeagues.tsx
+++ b/packages/web/components/Patron/Join/RankedLeagues.tsx
@@ -1,9 +1,18 @@
 import { Container } from '@metafam/ds';
+import { TokenBalancesFragment } from 'graphql/autogen/types';
 
 import PerksGrid from './PerksGrid';
 
-export const RankedLeagues = () => (
+type Props = {
+  pSeedPrice: number;
+  pSeedHolders: TokenBalancesFragment[];
+};
+
+export const RankedLeagues: React.FC<Props> = ({
+  pSeedPrice,
+  pSeedHolders,
+}) => (
   <Container as="section" className="mg-patron-join-section" my={[8, 8, 8, 12]}>
-    <PerksGrid />
+    <PerksGrid pSeedPrice={pSeedPrice} pSeedHolders={pSeedHolders} />
   </Container>
 );

--- a/packages/web/components/Patron/Join/RankedLeagues.tsx
+++ b/packages/web/components/Patron/Join/RankedLeagues.tsx
@@ -1,10 +1,11 @@
 import { Container } from '@metafam/ds';
+import { Maybe } from '@metafam/utils';
 import { TokenBalancesFragment } from 'graphql/autogen/types';
 
 import PerksGrid from './PerksGrid';
 
 type Props = {
-  pSeedPrice: number;
+  pSeedPrice: Maybe<number>;
   pSeedHolders: TokenBalancesFragment[];
 };
 
@@ -13,6 +14,6 @@ export const RankedLeagues: React.FC<Props> = ({
   pSeedHolders,
 }) => (
   <Container as="section" className="mg-patron-join-section" my={[8, 8, 8, 12]}>
-    <PerksGrid pSeedPrice={pSeedPrice} pSeedHolders={pSeedHolders} />
+    <PerksGrid {...{ pSeedPrice, pSeedHolders }} />
   </Container>
 );

--- a/packages/web/components/Patron/PatronList.tsx
+++ b/packages/web/components/Patron/PatronList.tsx
@@ -5,16 +5,17 @@ import React from 'react';
 
 type Props = {
   patrons: Array<Patron>;
+  pSeedPrice: number;
 };
 
-export const PatronList: React.FC<Props> = ({ patrons }) => (
+export const PatronList: React.FC<Props> = ({ patrons, pSeedPrice }) => (
   <SimpleGrid
     columns={[1, null, 2, 3]}
     spacing="8"
     autoRows="minmax(35rem, auto)"
   >
     {patrons.map((p, i) => (
-      <PatronTile key={p.id} patron={p} index={i} />
+      <PatronTile key={p.id} patron={p} index={i} pSeedPrice={pSeedPrice} />
     ))}
   </SimpleGrid>
 );

--- a/packages/web/components/Patron/PatronList.tsx
+++ b/packages/web/components/Patron/PatronList.tsx
@@ -1,11 +1,12 @@
 import { SimpleGrid } from '@metafam/ds';
+import { Maybe } from '@metafam/utils';
 import { PatronTile } from 'components/Patron/PatronTile';
 import { Patron } from 'graphql/types';
 import React from 'react';
 
 type Props = {
   patrons: Array<Patron>;
-  pSeedPrice: number;
+  pSeedPrice: Maybe<number>;
 };
 
 export const PatronList: React.FC<Props> = ({ patrons, pSeedPrice }) => (
@@ -14,8 +15,8 @@ export const PatronList: React.FC<Props> = ({ patrons, pSeedPrice }) => (
     spacing="8"
     autoRows="minmax(35rem, auto)"
   >
-    {patrons.map((p, i) => (
-      <PatronTile key={p.id} patron={p} index={i} pSeedPrice={pSeedPrice} />
+    {patrons.map((patron, index) => (
+      <PatronTile key={patron.id} {...{ patron, index, pSeedPrice }} />
     ))}
   </SimpleGrid>
 );

--- a/packages/web/components/Patron/PatronTile.tsx
+++ b/packages/web/components/Patron/PatronTile.tsx
@@ -14,7 +14,7 @@ import {
   Wrap,
   WrapItem,
 } from '@metafam/ds';
-import { computeRank } from '@metafam/utils';
+import { computeRank, Constants } from '@metafam/utils';
 import { PlayerAvatar } from 'components/Player/PlayerAvatar';
 import { PlayerContacts } from 'components/Player/PlayerContacts';
 import { PlayerTileMemberships } from 'components/Player/PlayerTileMemberships';
@@ -84,8 +84,12 @@ export const PatronTile: React.FC<Props> = ({ index, patron, pSeedPrice }) => {
                   <WrapItem>
                     <MetaTag size="md">
                       {`$${(
-                        Number(utils.formatEther(patron.pSeedBalance)) *
-                        pSeedPrice
+                        parseFloat(
+                          utils.formatUnits(
+                            patron.pSeedBalance,
+                            Constants.PSEED_DECIMALS,
+                          ),
+                        ) * pSeedPrice
                       ).toLocaleString(undefined, {
                         maximumFractionDigits: 0,
                       })}`}

--- a/packages/web/components/Patron/PatronTile.tsx
+++ b/packages/web/components/Patron/PatronTile.tsx
@@ -20,27 +20,18 @@ import { PlayerContacts } from 'components/Player/PlayerContacts';
 import { PlayerTileMemberships } from 'components/Player/PlayerTileMemberships';
 import { SkillsTags } from 'components/Quest/Skills';
 import { utils } from 'ethers';
-import { Player, PlayerRank_Enum, Skill } from 'graphql/autogen/types';
+import { Player, Skill } from 'graphql/autogen/types';
 import { Patron } from 'graphql/types';
 import NextLink from 'next/link';
 import React, { useMemo } from 'react';
 import { FaGlobe } from 'react-icons/fa';
+import { PATRON_RANKS, PATRONS_PER_RANK } from 'utils/patronHelpers';
 import {
   getPlayerBanner,
   getPlayerDescription,
   getPlayerName,
   getPlayerURL,
 } from 'utils/playerHelpers';
-
-const PATRON_RANKS = [
-  PlayerRank_Enum.Diamond,
-  PlayerRank_Enum.Platinum,
-  PlayerRank_Enum.Gold,
-  PlayerRank_Enum.Silver,
-  PlayerRank_Enum.Bronze,
-];
-
-const PATRONS_PER_RANK = [7, 7, 7, 14, 21];
 
 type Props = {
   patron: Patron;

--- a/packages/web/components/Patron/PatronTile.tsx
+++ b/packages/web/components/Patron/PatronTile.tsx
@@ -36,11 +36,12 @@ import {
 type Props = {
   patron: Patron;
   index: number;
+  pSeedPrice: number;
 };
 
 const MAX_BIO_LENGTH = 240;
 
-export const PatronTile: React.FC<Props> = ({ index, patron }) => {
+export const PatronTile: React.FC<Props> = ({ index, patron, pSeedPrice }) => {
   const player = patron as Player;
   const patronRank = computeRank(index, PATRONS_PER_RANK, PATRON_RANKS);
   const { label: timeZone = null, offset = null } = useMemo(
@@ -82,9 +83,12 @@ export const PatronTile: React.FC<Props> = ({ index, patron }) => {
                 {patron.pSeedBalance != null && (
                   <WrapItem>
                     <MetaTag size="md">
-                      {`pSEED: ${Math.floor(
-                        Number(utils.formatEther(patron.pSeedBalance)),
-                      )}`}
+                      {`$${(
+                        Number(utils.formatEther(patron.pSeedBalance)) *
+                        pSeedPrice
+                      ).toLocaleString(undefined, {
+                        maximumFractionDigits: 0,
+                      })}`}
                     </MetaTag>
                   </WrapItem>
                 )}

--- a/packages/web/graphql/getPatrons.ts
+++ b/packages/web/graphql/getPatrons.ts
@@ -114,17 +114,17 @@ export const getPatrons = async (limit = 50): Promise<Array<Patron>> => {
   return patrons;
 };
 
-export const getPSeedPrice = async (): Promise<string | null | undefined> => {
+export const getPSeedPrice = async (): Promise<number> => {
   const { data, error } = await client
     .query<GetPSeedPriceQuery, GetPSeedPriceQueryVariables>(getPSeedPriceQuery)
     .toPromise();
 
-  if (data?.getPSeedInfo == null) {
+  if (data?.getPSeedInfo?.priceUsd == null) {
     if (error) {
       throw error;
     }
-    return null;
+    return 3.5;
   }
 
-  return data.getPSeedInfo.priceUsd;
+  return parseFloat(data.getPSeedInfo.priceUsd);
 };

--- a/packages/web/graphql/getPatrons.ts
+++ b/packages/web/graphql/getPatrons.ts
@@ -123,7 +123,7 @@ export const getPSeedPrice = async (): Promise<number> => {
     if (error) {
       throw error;
     }
-    return 3.5;
+    throw new Error('Could not determine pSeed USD value.');
   }
 
   return parseFloat(data.getPSeedInfo.priceUsd);

--- a/packages/web/graphql/getPatrons.ts
+++ b/packages/web/graphql/getPatrons.ts
@@ -1,8 +1,11 @@
 import {
   GetPatronsQuery,
   GetPatronsQueryVariables,
+  GetpSeedBalanceQueryVariables,
   GetpSeedHoldersQuery,
   GetpSeedHoldersQueryVariables,
+  GetPSeedPriceQuery,
+  GetPSeedPriceQueryVariables,
   Player,
   TokenBalancesFragment as TokenBalancesFragmentType,
 } from 'graphql/autogen/types';
@@ -38,6 +41,14 @@ const pSeedHoldersQuery = /* GraphQL */ `
   ${TokenBalancesFragment}
 `;
 
+const getPSeedPriceQuery = /* GraphQL */ `
+  query GetPSeedPrice {
+    getPSeedInfo {
+      priceUsd
+    }
+  }
+`;
+
 const getPlayersFromAddresses = async (
   addresses: Array<string>,
   limit: number,
@@ -59,7 +70,7 @@ const getPlayersFromAddresses = async (
   return data.player as Array<Player>;
 };
 
-const getpSeedHolders = async (
+export const getPSeedHolders = async (
   limit: number,
 ): Promise<Array<TokenBalancesFragmentType>> => {
   const { data, error } = await client
@@ -80,7 +91,7 @@ const getpSeedHolders = async (
 };
 
 export const getPatrons = async (limit = 50): Promise<Array<Patron>> => {
-  const tokenBalances: Array<TokenBalancesFragmentType> = await getpSeedHolders(
+  const tokenBalances: Array<TokenBalancesFragmentType> = await getPSeedHolders(
     limit,
   );
 
@@ -102,4 +113,19 @@ export const getPatrons = async (limit = 50): Promise<Array<Patron>> => {
   );
 
   return patrons;
+};
+
+export const getPSeedPrice = async (): Promise<string | null | undefined> => {
+  const { data, error } = await client
+    .query<GetPSeedPriceQuery, GetPSeedPriceQueryVariables>(getPSeedPriceQuery)
+    .toPromise();
+
+  if (data?.getPSeedInfo == null) {
+    if (error) {
+      throw error;
+    }
+    return null;
+  }
+
+  return data.getPSeedInfo.priceUsd;
 };

--- a/packages/web/graphql/getPatrons.ts
+++ b/packages/web/graphql/getPatrons.ts
@@ -1,7 +1,6 @@
 import {
   GetPatronsQuery,
   GetPatronsQueryVariables,
-  GetpSeedBalanceQueryVariables,
   GetpSeedHoldersQuery,
   GetpSeedHoldersQueryVariables,
   GetPSeedPriceQuery,

--- a/packages/web/pages/community/patrons.tsx
+++ b/packages/web/pages/community/patrons.tsx
@@ -1,7 +1,7 @@
 import { PageContainer } from 'components/Container';
 import { PatronList } from 'components/Patron/PatronList';
 import { HeadComponent } from 'components/Seo';
-import { getPatrons } from 'graphql/getPatrons';
+import { getPatrons, getPSeedPrice } from 'graphql/getPatrons';
 import { InferGetStaticPropsType } from 'next';
 import React from 'react';
 
@@ -9,22 +9,24 @@ type Props = InferGetStaticPropsType<typeof getStaticProps>;
 
 export const getStaticProps = async () => {
   const patrons = await getPatrons();
+  const pSeedPrice = await getPSeedPrice();
   return {
     props: {
       patrons,
+      pSeedPrice,
     },
     revalidate: 1,
   };
 };
 
-const PatronsPage: React.FC<Props> = ({ patrons }) => (
+const PatronsPage: React.FC<Props> = ({ patrons, pSeedPrice }) => (
   <PageContainer>
     <HeadComponent
       title="MetaGame Patrons"
       description="MetaGame is a Massive Online Coordination Game! MetaGame’s Patrons enable us to succeed by helping us with funds."
       url="https://my.metagame.wtf/community/patrons"
     />
-    <PatronList patrons={patrons} />
+    <PatronList patrons={patrons} pSeedPrice={pSeedPrice} />
   </PageContainer>
 );
 

--- a/packages/web/pages/community/patrons.tsx
+++ b/packages/web/pages/community/patrons.tsx
@@ -9,7 +9,10 @@ type Props = InferGetStaticPropsType<typeof getStaticProps>;
 
 export const getStaticProps = async () => {
   const patrons = await getPatrons();
-  const pSeedPrice = await getPSeedPrice();
+  const pSeedPrice = await getPSeedPrice().catch((error) => {
+    console.error('Error fetching pSeed price', error);
+    return null;
+  });
   return {
     props: {
       patrons,
@@ -26,7 +29,7 @@ const PatronsPage: React.FC<Props> = ({ patrons, pSeedPrice }) => (
       description="MetaGame is a Massive Online Coordination Game! MetaGame’s Patrons enable us to succeed by helping us with funds."
       url="https://my.metagame.wtf/community/patrons"
     />
-    <PatronList patrons={patrons} pSeedPrice={pSeedPrice} />
+    <PatronList {...{ patrons, pSeedPrice }} />
   </PageContainer>
 );
 

--- a/packages/web/pages/join/patron/index.tsx
+++ b/packages/web/pages/join/patron/index.tsx
@@ -34,7 +34,10 @@ export const getStaticProps = async () => {
     0,
   );
   const pSeedHolders = await getPSeedHolders(rankedPatronCount);
-  const pSeedPrice = await getPSeedPrice();
+  const pSeedPrice = await getPSeedPrice().catch((error) => {
+    console.error('Error fetching pSeed price', error);
+    return null;
+  });
 
   return {
     props: {
@@ -106,7 +109,7 @@ const PatronsJoinLanding: React.FC<Props> = ({
 
       {/* Section: Ranked Leagues & Perks */}
 
-      {<RankedLeagues pSeedPrice={pSeedPrice} pSeedHolders={pSeedHolders} />}
+      {<RankedLeagues {...{ pSeedPrice, pSeedHolders }} />}
 
       {/* Section: Other patrons include... */}
 

--- a/packages/web/pages/join/patron/index.tsx
+++ b/packages/web/pages/join/patron/index.tsx
@@ -27,7 +27,7 @@ import { PATRONS_PER_RANK } from 'utils/patronHelpers';
 type Props = InferGetStaticPropsType<typeof getStaticProps>;
 
 export const getStaticProps = async () => {
-  const patrons = await getPatrons(6);
+  const patrons = await getPatrons();
 
   const rankedPatronCount = PATRONS_PER_RANK.reduce(
     (total, current) => total + current,

--- a/packages/web/pages/join/patron/index.tsx
+++ b/packages/web/pages/join/patron/index.tsx
@@ -27,7 +27,7 @@ import { PATRONS_PER_RANK } from 'utils/patronHelpers';
 type Props = InferGetStaticPropsType<typeof getStaticProps>;
 
 export const getStaticProps = async () => {
-  const patrons = await getPatrons();
+  const patrons = await getPatrons(6);
 
   const rankedPatronCount = PATRONS_PER_RANK.reduce(
     (total, current) => total + current,

--- a/packages/web/pages/join/patron/index.tsx
+++ b/packages/web/pages/join/patron/index.tsx
@@ -19,23 +19,40 @@ import { WhatsTheProduct } from 'components/Patron/Join/WhatsTheProduct';
 import { WhoArePatrons } from 'components/Patron/Join/WhoArePatrons';
 import { PatronList } from 'components/Patron/PatronList';
 import { HeadComponent } from 'components/Seo';
-import { getPatrons } from 'graphql/getPatrons';
+import { getPatrons, getPSeedHolders, getPSeedPrice } from 'graphql/getPatrons';
 import { InferGetStaticPropsType } from 'next';
 import React, { useRef } from 'react';
+import { PATRONS_PER_RANK } from 'utils/patronHelpers';
 
 type Props = InferGetStaticPropsType<typeof getStaticProps>;
 
 export const getStaticProps = async () => {
   const patrons = await getPatrons();
+
+  const rankedPatronCount = PATRONS_PER_RANK.reduce(
+    (total, current) => total + current,
+    0,
+  );
+  const pSeedHolders = await getPSeedHolders(rankedPatronCount);
+  const pSeedPriceResult = await getPSeedPrice();
+  const pSeedPrice =
+    pSeedPriceResult != null ? parseFloat(pSeedPriceResult) : 3.5;
+
   return {
     props: {
       patrons: patrons || [],
+      pSeedHolders,
+      pSeedPrice,
     },
     revalidate: 1,
   };
 };
 
-const PatronsJoinLanding: React.FC<Props> = ({ patrons }) => {
+const PatronsJoinLanding: React.FC<Props> = ({
+  patrons,
+  pSeedHolders,
+  pSeedPrice,
+}) => {
   const topRef = useRef<HTMLDivElement>(null);
 
   function handleBackClick() {
@@ -91,7 +108,7 @@ const PatronsJoinLanding: React.FC<Props> = ({ patrons }) => {
 
       {/* Section: Ranked Leagues & Perks */}
 
-      {<RankedLeagues />}
+      {<RankedLeagues pSeedPrice={pSeedPrice} pSeedHolders={pSeedHolders} />}
 
       {/* Section: Other patrons include... */}
 

--- a/packages/web/pages/join/patron/index.tsx
+++ b/packages/web/pages/join/patron/index.tsx
@@ -34,9 +34,7 @@ export const getStaticProps = async () => {
     0,
   );
   const pSeedHolders = await getPSeedHolders(rankedPatronCount);
-  const pSeedPriceResult = await getPSeedPrice();
-  const pSeedPrice =
-    pSeedPriceResult != null ? parseFloat(pSeedPriceResult) : 3.5;
+  const pSeedPrice = await getPSeedPrice();
 
   return {
     props: {
@@ -130,7 +128,7 @@ const PatronsJoinLanding: React.FC<Props> = ({
           px={0}
           centerContent
         >
-          <PatronList patrons={patrons.slice(0, 6)} />
+          <PatronList patrons={patrons.slice(0, 6)} pSeedPrice={pSeedPrice} />
           <Box mt={12} mb={4} px={2}>
             <MetaButton
               maxW=""

--- a/packages/web/pages/join/patron/index.tsx
+++ b/packages/web/pages/join/patron/index.tsx
@@ -151,7 +151,7 @@ const PatronsJoinLanding: React.FC<Props> = ({
                 transform: 'scale(0.8)',
               }}
             >
-              LOAD MORE
+              VIEW ALL PATRONS
             </MetaButton>
           </Box>
         </Container>

--- a/packages/web/utils/patronHelpers.ts
+++ b/packages/web/utils/patronHelpers.ts
@@ -1,4 +1,4 @@
-import { Constants, Maybe } from '@metafam/utils';
+import { Constants } from '@metafam/utils';
 import { utils } from 'ethers';
 import { PlayerRank_Enum, TokenBalancesFragment } from 'graphql/autogen/types';
 
@@ -23,7 +23,6 @@ export const getLeagueCount = (rank: PlayerRank_Enum) => {
 export const getLeagueCutoff = (
   rank: PlayerRank_Enum,
   pSeedHolders: TokenBalancesFragment[],
-  pSeedPrice: number,
 ) => {
   if (pSeedHolders == null || pSeedHolders.length === 0) {
     return 0;
@@ -48,18 +47,12 @@ export const getLeagueCutoff = (
           ),
         );
 
-  return pSeedCutoff * pSeedPrice;
+  return pSeedCutoff;
 };
 
-export const getPatronHoldingsUsd = (
-  pSeedHolder: Maybe<TokenBalancesFragment>,
-  pSeedPrice: number,
-) => {
-  if (pSeedHolder == null) {
-    return MIN_PATRON_PSEEDS * pSeedPrice;
-  }
+export const getPatronPSeedHoldings = (pSeedHolder: TokenBalancesFragment) => {
   const pSeedBalance = parseFloat(
     utils.formatUnits(pSeedHolder.pSeedBalance, Constants.PSEED_DECIMALS),
   );
-  return pSeedBalance * pSeedPrice;
+  return pSeedBalance;
 };

--- a/packages/web/utils/patronHelpers.ts
+++ b/packages/web/utils/patronHelpers.ts
@@ -1,0 +1,57 @@
+import { Constants } from '@metafam/utils';
+import { PlayerRank_Enum, TokenBalancesFragment } from 'graphql/autogen/types';
+import { Patron } from 'graphql/types';
+
+export const PATRON_RANKS = [
+  PlayerRank_Enum.Diamond,
+  PlayerRank_Enum.Platinum,
+  PlayerRank_Enum.Gold,
+  PlayerRank_Enum.Silver,
+  PlayerRank_Enum.Bronze,
+];
+
+export const PATRONS_PER_RANK = [7, 7, 7, 14, 21];
+
+export const NUM_PATRONS = 150;
+export const MIN_PATRON_PSEEDS = 8;
+
+export const getLeagueCount = (rank: PlayerRank_Enum) => {
+  const index = PATRON_RANKS.findIndex((patronRank) => patronRank === rank);
+  return PATRONS_PER_RANK[index];
+};
+
+export const getLeagueCutoff = (
+  rank: PlayerRank_Enum,
+  pSeedHolders: TokenBalancesFragment[],
+  pSeedPrice: number,
+) => {
+  if (pSeedHolders == null || pSeedHolders.length === 0) {
+    return 0;
+  }
+  const leagueIndex = PATRON_RANKS.findIndex(
+    (patronRank) => patronRank === rank,
+  );
+  // this is the patron in the league with the least amount of holdings
+  const indexOfLastPatronInLeague =
+    PATRONS_PER_RANK.reduce(
+      (total, leagueCount, index) =>
+        leagueIndex < index ? total : total + leagueCount,
+      0,
+    ) - 1;
+  const pSeedCutoff =
+    pSeedHolders.length <= indexOfLastPatronInLeague
+      ? MIN_PATRON_PSEEDS
+      : parseFloat(pSeedHolders[indexOfLastPatronInLeague].pSeedBalance) /
+        Constants.PSEED_CONTRACT_DIVISOR;
+
+  return pSeedCutoff * pSeedPrice;
+};
+
+export const getPatronHoldingsUsd = (
+  pSeedHolder: TokenBalancesFragment,
+  pSeedPrice: number,
+) => {
+  const pSeedBalance =
+    parseFloat(pSeedHolder.pSeedBalance) / Constants.PSEED_CONTRACT_DIVISOR;
+  return pSeedBalance * pSeedPrice;
+};

--- a/packages/web/utils/patronHelpers.ts
+++ b/packages/web/utils/patronHelpers.ts
@@ -1,4 +1,5 @@
 import { Constants, Maybe } from '@metafam/utils';
+import { utils } from 'ethers';
 import { PlayerRank_Enum, TokenBalancesFragment } from 'graphql/autogen/types';
 
 export const PATRON_RANKS = [
@@ -40,8 +41,12 @@ export const getLeagueCutoff = (
   const pSeedCutoff =
     pSeedHolders.length <= indexOfLastPatronInLeague
       ? MIN_PATRON_PSEEDS
-      : parseFloat(pSeedHolders[indexOfLastPatronInLeague].pSeedBalance) /
-        Constants.PSEED_CONTRACT_DIVISOR;
+      : parseFloat(
+          utils.formatUnits(
+            pSeedHolders[indexOfLastPatronInLeague].pSeedBalance,
+            Constants.PSEED_DECIMALS,
+          ),
+        );
 
   return pSeedCutoff * pSeedPrice;
 };
@@ -53,7 +58,8 @@ export const getPatronHoldingsUsd = (
   if (pSeedHolder == null) {
     return MIN_PATRON_PSEEDS * pSeedPrice;
   }
-  const pSeedBalance =
-    parseFloat(pSeedHolder.pSeedBalance) / Constants.PSEED_CONTRACT_DIVISOR;
+  const pSeedBalance = parseFloat(
+    utils.formatUnits(pSeedHolder.pSeedBalance, Constants.PSEED_DECIMALS),
+  );
   return pSeedBalance * pSeedPrice;
 };

--- a/packages/web/utils/patronHelpers.ts
+++ b/packages/web/utils/patronHelpers.ts
@@ -1,6 +1,5 @@
-import { Constants } from '@metafam/utils';
+import { Constants, Maybe } from '@metafam/utils';
 import { PlayerRank_Enum, TokenBalancesFragment } from 'graphql/autogen/types';
-import { Patron } from 'graphql/types';
 
 export const PATRON_RANKS = [
   PlayerRank_Enum.Diamond,
@@ -48,9 +47,12 @@ export const getLeagueCutoff = (
 };
 
 export const getPatronHoldingsUsd = (
-  pSeedHolder: TokenBalancesFragment,
+  pSeedHolder: Maybe<TokenBalancesFragment>,
   pSeedPrice: number,
 ) => {
+  if (pSeedHolder == null) {
+    return MIN_PATRON_PSEEDS * pSeedPrice;
+  }
   const pSeedBalance =
     parseFloat(pSeedHolder.pSeedBalance) / Constants.PSEED_CONTRACT_DIVISOR;
   return pSeedBalance * pSeedPrice;

--- a/packages/web/utils/roleHelpers.ts
+++ b/packages/web/utils/roleHelpers.ts
@@ -11,23 +11,3 @@ export type CategoryOption = {
   label: string;
   options: Array<RoleOption>;
 };
-
-// export const parseRoles = (
-//   roles: Array<PlayerRole>,
-// ): Array<CategoryOption> => {
-//   const rolesMap: RoleMap = {};
-//   roles.forEach((role) => {
-//     if (!(role.category in rolesMap)) {
-//       rolesMap[role.category] = {
-//         label: role.category,
-//         options: [],
-//       };
-//     }
-//     rolesMap[role.category].options?.push({
-//       value: role.id,
-//       label: role.name,
-//       ...role,
-//     });
-//   });
-//   return Object.values(rolesMap);
-// };


### PR DESCRIPTION
## Overview

**What features/fixes does this PR include?**

- Filter out our multisig address from the [top pSeed holders](https://polygonscan.com/token/0x8a8fcd351ed553fc75aecbc566a32f94471f302e#balances) on Polygon
- For each patron league, display the amount in USD of the holder with the least amount of holdings. This is the cutoff to get into a given league
- Refactored some of the patrons constants into a utils file

**Please provide the GitHub issue number**

Addresses part of #1412 
