### PR TITLE
Refactor: proper guild sorting

### DIFF
--- a/hasura/metadata/tables.yaml
+++ b/hasura/metadata/tables.yaml
@@ -62,10 +62,6 @@
       filter: {}
 - table:
     schema: public
-    name: GuildPosition
-  is_enum: true
-- table:
-    schema: public
     name: GuildStatus
   is_enum: true
 - table:
@@ -322,7 +318,6 @@
       - logo
       - membership_through_discord
       - name
-      - position
       - profile_layout
       - show_discord_announcements
       - status
@@ -343,7 +338,6 @@
       - logo
       - membership_through_discord
       - name
-      - position
       - profile_layout
       - show_discord_announcements
       - status

--- a/hasura/metadata/tables.yaml
+++ b/hasura/metadata/tables.yaml
@@ -256,6 +256,7 @@
       show_discord_announcements: showDiscordAnnouncements
       discord_id: discordId
       twitter_url: twitterUrl
+      sort_position: sortPosition
       membership_through_discord: membershipThroughDiscord
       profile_layout: profileLayout
       discord_invite_url: discordInviteUrl
@@ -320,6 +321,7 @@
       - name
       - profile_layout
       - show_discord_announcements
+      - sort_position
       - status
       - twitter_url
       - type
@@ -340,6 +342,7 @@
       - name
       - profile_layout
       - show_discord_announcements
+      - sort_position
       - status
       - twitter_url
       - type

--- a/hasura/migrations/1666752566691_alter_table_public_guild_drop_column_position/down.sql
+++ b/hasura/migrations/1666752566691_alter_table_public_guild_drop_column_position/down.sql
@@ -1,0 +1,3 @@
+ALTER TABLE "public"."guild" ADD COLUMN "position" text;
+ALTER TABLE "public"."guild" ALTER COLUMN "position" DROP NOT NULL;
+ALTER TABLE "public"."guild" ADD CONSTRAINT guild_position_fkey FOREIGN KEY (position) REFERENCES "public"."GuildPosition" (position) ON DELETE restrict ON UPDATE cascade;

--- a/hasura/migrations/1666752566691_alter_table_public_guild_drop_column_position/up.sql
+++ b/hasura/migrations/1666752566691_alter_table_public_guild_drop_column_position/up.sql
@@ -1,0 +1,2 @@
+ALTER TABLE "public"."guild" DROP COLUMN "position" CASCADE;
+DROP TABLE "public"."GuildPosition";

--- a/hasura/migrations/1666753166581_alter_table_public_guild_add_column_sort_position/down.sql
+++ b/hasura/migrations/1666753166581_alter_table_public_guild_add_column_sort_position/down.sql
@@ -1,0 +1,1 @@
+ALTER TABLE "public"."guild" DROP COLUMN "sort_position";

--- a/hasura/migrations/1666753166581_alter_table_public_guild_add_column_sort_position/up.sql
+++ b/hasura/migrations/1666753166581_alter_table_public_guild_add_column_sort_position/up.sql
@@ -1,0 +1,1 @@
+ALTER TABLE "public"."guild" ADD COLUMN "sort_position" integer NULL UNIQUE;

--- a/packages/backend/src/handlers/actions/guild/discord/oauthHandler.ts
+++ b/packages/backend/src/handlers/actions/guild/discord/oauthHandler.ts
@@ -12,7 +12,6 @@ import {
   DiscordGuildAuthResponse,
   Guild_Insert_Input,
   Guild_Metadata_Insert_Input,
-  GuildPosition_Enum,
   GuildStatus_Enum,
   GuildType_Enum,
 } from '../../../../lib/autogen/hasura-sdk';
@@ -148,7 +147,6 @@ const createNewGuild = async (
     guildname: discordGuild.name.toLowerCase().replace(/[^a-z0-9]/g, ''),
     discordId: discordGuild.id,
     status: GuildStatus_Enum.Pending,
-    position: GuildPosition_Enum.External,
     membershipThroughDiscord: true,
     showDiscordAnnouncements:
       discordGuild.roles.find((role) => role.name === 'MetaGame')

--- a/packages/web/components/Guild/Section/GuildHero.tsx
+++ b/packages/web/components/Guild/Section/GuildHero.tsx
@@ -81,7 +81,6 @@ export const GuildHero: React.FC<Props> = ({ guild, editing }) => {
           <Text fontSize="md" color="blueLight">
             {`${guild.type} GUILD`}
           </Text>
-          <Text fontSize="md">{`${guild.position} GUILD`}</Text>
         </Box>
         <Box>
           <Text>{guild.description}</Text>

--- a/packages/web/graphql/fragments.ts
+++ b/packages/web/graphql/fragments.ts
@@ -76,7 +76,6 @@ export const GuildFragment = /* GraphQL */ `
     logo
     name
     type
-    position
     websiteUrl
     githubUrl
     twitterUrl

--- a/packages/web/graphql/queries/guild.ts
+++ b/packages/web/graphql/queries/guild.ts
@@ -77,7 +77,11 @@ export const getAdministeredGuildsQuery = /* GraphQL */ `
 
 const guildsQuery = /* GraphQL */ `
   query GetGuilds($limit: Int) {
-    guild(where: { status: { _eq: ACTIVE } }, limit: $limit) {
+    guild(
+      where: { status: { _eq: ACTIVE } }
+      limit: $limit
+      order_by: { sortPosition: asc_nulls_last }
+    ) {
       ...GuildFragment
     }
   }

--- a/packages/web/pages/community/guilds.tsx
+++ b/packages/web/pages/community/guilds.tsx
@@ -1,61 +1,14 @@
 import { PageContainer } from 'components/Container';
 import { GuildList } from 'components/Guild/GuildList';
 import { HeadComponent } from 'components/Seo';
-import { GuildFragment } from 'graphql/autogen/types';
 import { getGuilds } from 'graphql/queries/guild';
 import { InferGetStaticPropsType } from 'next';
 import React from 'react';
 
 type Props = InferGetStaticPropsType<typeof getStaticProps>;
 
-// TODO: move this order to based on metamanifesto nft / pSEED holding in the future
-const GUILD_ORDER = [
-  { guildname: 'cr8rdao', name: 'CRΞ8R DAO' },
-  { guildname: 'metacartel', name: 'MetaCartel' },
-  { guildname: 'panvala', name: 'Panvala' },
-  { guildname: 'daohaus', name: 'DAOhaus' },
-  { guildname: 'metafactory', name: 'MetaFactory' },
-  { guildname: 'bloomnetwork', name: 'Bloom Network' },
-  { guildname: 'metafam', name: 'MetaFam' },
-  { guildname: 'raidguild', name: 'RaidGuild' },
-  { guildname: 'sourcecred', name: 'SourceCred' },
-  { guildname: 'metacartelventures', name: 'MetaCartel Ventures' },
-  { guildname: 'questchains', name: 'Quest Chains' },
-  { guildname: 'Giveth', name: 'Giveth' },
-  { guildname: 'liminalvillage', name: 'Liminal Village' },
-  { guildname: 'projectark', name: 'Project Ark' },
-  { guildname: 'rndao', name: 'rnDAO' },
-  { guildname: 'wgmi', name: 'wgmi' },
-  { guildname: 'opolis', name: 'Opolis' },
-  { guildname: 'wildfiredao', name: 'Wildfire' },
-  { guildname: '1hive', name: '1Hive' },
-  { guildname: 'atlantisworld', name: 'Atlantis World' },
-  { guildname: 'deepwork', name: 'Deep Work Studio' },
-  { guildname: 'ethernautdao', name: 'ΞthernautDAO' },
-  { guildname: 'storyguild', name: 'Story Guild' },
-  { guildname: 'commonsstack', name: 'The Commons Stack' },
-  { guildname: 'mgd', name: 'MGD DAO' },
-  { guildname: 'safary', name: 'Safary 🦁' },
-  { guildname: 'grdn', name: 'GRDN (🌎, 🌍, 🌏)' },
-  { guildname: 'dorg', name: 'dOrg' },
-  { guildname: 'buidl', name: 'Buidl Guidl' },
-  { guildname: 'TEC', name: 'Token Engineering Commons' },
-];
-
-const sortGuild = (a: GuildFragment, b: GuildFragment) => {
-  const guildIds = GUILD_ORDER.map((g) => g.guildname);
-  const indexA = guildIds.indexOf(a.guildname);
-  const indexB = guildIds.indexOf(b.guildname);
-
-  if (indexB === indexA) return 0;
-  if (indexB === -1) return -1;
-  if (indexA === -1) return 1;
-
-  return indexA > indexB ? 1 : -1;
-};
-
 export const getStaticProps = async () => {
-  const guilds = (await getGuilds()).sort(sortGuild);
+  const guilds = await getGuilds();
 
   return {
     props: {

--- a/schema.graphql
+++ b/schema.graphql
@@ -1580,6 +1580,7 @@ type guild {
     where: quest_bool_exp
   ): quest_aggregate!
   showDiscordAnnouncements: Boolean!
+  sortPosition: Int
   status: GuildStatus_enum!
   twitterUrl: String
 
@@ -1600,18 +1601,34 @@ type guild_aggregate {
 aggregate fields of "guild"
 """
 type guild_aggregate_fields {
+  avg: guild_avg_fields
   count(columns: [guild_select_column!], distinct: Boolean): Int
   max: guild_max_fields
   min: guild_min_fields
+  stddev: guild_stddev_fields
+  stddev_pop: guild_stddev_pop_fields
+  stddev_samp: guild_stddev_samp_fields
+  sum: guild_sum_fields
+  var_pop: guild_var_pop_fields
+  var_samp: guild_var_samp_fields
+  variance: guild_variance_fields
 }
 
 """
 order by aggregate values of table "guild"
 """
 input guild_aggregate_order_by {
+  avg: guild_avg_order_by
   count: order_by
   max: guild_max_order_by
   min: guild_min_order_by
+  stddev: guild_stddev_order_by
+  stddev_pop: guild_stddev_pop_order_by
+  stddev_samp: guild_stddev_samp_order_by
+  sum: guild_sum_order_by
+  var_pop: guild_var_pop_order_by
+  var_samp: guild_var_samp_order_by
+  variance: guild_variance_order_by
 }
 
 """
@@ -1620,6 +1637,18 @@ input type for inserting array relation for remote table "guild"
 input guild_arr_rel_insert_input {
   data: [guild_insert_input!]!
   on_conflict: guild_on_conflict
+}
+
+"""aggregate avg on columns"""
+type guild_avg_fields {
+  sortPosition: Float
+}
+
+"""
+order by avg() on columns of table "guild"
+"""
+input guild_avg_order_by {
+  sortPosition: order_by
 }
 
 """
@@ -1646,6 +1675,7 @@ input guild_bool_exp {
   profileLayout: String_comparison_exp
   quests: quest_bool_exp
   showDiscordAnnouncements: Boolean_comparison_exp
+  sortPosition: Int_comparison_exp
   status: GuildStatus_enum_comparison_exp
   twitterUrl: String_comparison_exp
   type: GuildType_enum_comparison_exp
@@ -1664,6 +1694,16 @@ enum guild_constraint {
 
   """unique or primary key constraint"""
   guild_discord_id_key
+
+  """unique or primary key constraint"""
+  guild_sort_position_key
+}
+
+"""
+input type for incrementing integer column in table "guild"
+"""
+input guild_inc_input {
+  sortPosition: Int
 }
 
 """
@@ -1687,6 +1727,7 @@ input guild_insert_input {
   profileLayout: String
   quests: quest_arr_rel_insert_input
   showDiscordAnnouncements: Boolean
+  sortPosition: Int
   status: GuildStatus_enum
   twitterUrl: String
   type: GuildType_enum
@@ -1705,6 +1746,7 @@ type guild_max_fields {
   logo: String
   name: String
   profileLayout: String
+  sortPosition: Int
   twitterUrl: String
   websiteUrl: String
 }
@@ -1723,6 +1765,7 @@ input guild_max_order_by {
   logo: order_by
   name: order_by
   profileLayout: order_by
+  sortPosition: order_by
   twitterUrl: order_by
   websiteUrl: order_by
 }
@@ -1989,6 +2032,7 @@ type guild_min_fields {
   logo: String
   name: String
   profileLayout: String
+  sortPosition: Int
   twitterUrl: String
   websiteUrl: String
 }
@@ -2007,6 +2051,7 @@ input guild_min_order_by {
   logo: order_by
   name: order_by
   profileLayout: order_by
+  sortPosition: order_by
   twitterUrl: order_by
   websiteUrl: order_by
 }
@@ -2060,6 +2105,7 @@ input guild_order_by {
   profileLayout: order_by
   quests_aggregate: quest_aggregate_order_by
   showDiscordAnnouncements: order_by
+  sortPosition: order_by
   status: order_by
   twitterUrl: order_by
   type: order_by
@@ -2299,6 +2345,9 @@ enum guild_select_column {
   showDiscordAnnouncements
 
   """column name"""
+  sortPosition
+
+  """column name"""
   status
 
   """column name"""
@@ -2327,10 +2376,59 @@ input guild_set_input {
   name: String
   profileLayout: String
   showDiscordAnnouncements: Boolean
+  sortPosition: Int
   status: GuildStatus_enum
   twitterUrl: String
   type: GuildType_enum
   websiteUrl: String
+}
+
+"""aggregate stddev on columns"""
+type guild_stddev_fields {
+  sortPosition: Float
+}
+
+"""
+order by stddev() on columns of table "guild"
+"""
+input guild_stddev_order_by {
+  sortPosition: order_by
+}
+
+"""aggregate stddev_pop on columns"""
+type guild_stddev_pop_fields {
+  sortPosition: Float
+}
+
+"""
+order by stddev_pop() on columns of table "guild"
+"""
+input guild_stddev_pop_order_by {
+  sortPosition: order_by
+}
+
+"""aggregate stddev_samp on columns"""
+type guild_stddev_samp_fields {
+  sortPosition: Float
+}
+
+"""
+order by stddev_samp() on columns of table "guild"
+"""
+input guild_stddev_samp_order_by {
+  sortPosition: order_by
+}
+
+"""aggregate sum on columns"""
+type guild_sum_fields {
+  sortPosition: Int
+}
+
+"""
+order by sum() on columns of table "guild"
+"""
+input guild_sum_order_by {
+  sortPosition: order_by
 }
 
 """
@@ -2374,6 +2472,9 @@ enum guild_update_column {
   showDiscordAnnouncements
 
   """column name"""
+  sortPosition
+
+  """column name"""
   status
 
   """column name"""
@@ -2384,6 +2485,42 @@ enum guild_update_column {
 
   """column name"""
   websiteUrl
+}
+
+"""aggregate var_pop on columns"""
+type guild_var_pop_fields {
+  sortPosition: Float
+}
+
+"""
+order by var_pop() on columns of table "guild"
+"""
+input guild_var_pop_order_by {
+  sortPosition: order_by
+}
+
+"""aggregate var_samp on columns"""
+type guild_var_samp_fields {
+  sortPosition: Float
+}
+
+"""
+order by var_samp() on columns of table "guild"
+"""
+input guild_var_samp_order_by {
+  sortPosition: order_by
+}
+
+"""aggregate variance on columns"""
+type guild_variance_fields {
+  sortPosition: Float
+}
+
+"""
+order by variance() on columns of table "guild"
+"""
+input guild_variance_order_by {
+  sortPosition: order_by
 }
 
 input GuildDaoInput {
@@ -4225,6 +4362,9 @@ type mutation_root {
   update data of the table: "guild"
   """
   update_guild(
+    """increments the integer columns with given value of the filtered values"""
+    _inc: guild_inc_input
+
     """sets the columns of the filtered rows to the given values"""
     _set: guild_set_input
 
@@ -4236,6 +4376,9 @@ type mutation_root {
   update single row of the table: "guild"
   """
   update_guild_by_pk(
+    """increments the integer columns with given value of the filtered values"""
+    _inc: guild_inc_input
+
     """sets the columns of the filtered rows to the given values"""
     _set: guild_set_input
     pk_columns: guild_pk_columns_input!

--- a/schema.graphql
+++ b/schema.graphql
@@ -1542,7 +1542,6 @@ type guild {
   """An object relationship"""
   metadata: guild_metadata
   name: String!
-  position: GuildPosition_enum
   profileLayout: String
 
   """An array relationship"""
@@ -1644,7 +1643,6 @@ input guild_bool_exp {
   membershipThroughDiscord: Boolean_comparison_exp
   metadata: guild_metadata_bool_exp
   name: String_comparison_exp
-  position: GuildPosition_enum_comparison_exp
   profileLayout: String_comparison_exp
   quests: quest_bool_exp
   showDiscordAnnouncements: Boolean_comparison_exp
@@ -1686,7 +1684,6 @@ input guild_insert_input {
   membershipThroughDiscord: Boolean
   metadata: guild_metadata_obj_rel_insert_input
   name: String
-  position: GuildPosition_enum
   profileLayout: String
   quests: quest_arr_rel_insert_input
   showDiscordAnnouncements: Boolean
@@ -2060,7 +2057,6 @@ input guild_order_by {
   membershipThroughDiscord: order_by
   metadata: guild_metadata_order_by
   name: order_by
-  position: order_by
   profileLayout: order_by
   quests_aggregate: quest_aggregate_order_by
   showDiscordAnnouncements: order_by
@@ -2297,9 +2293,6 @@ enum guild_select_column {
   name
 
   """column name"""
-  position
-
-  """column name"""
   profileLayout
 
   """column name"""
@@ -2332,7 +2325,6 @@ input guild_set_input {
   logo: String
   membershipThroughDiscord: Boolean
   name: String
-  position: GuildPosition_enum
   profileLayout: String
   showDiscordAnnouncements: Boolean
   status: GuildStatus_enum
@@ -2374,9 +2366,6 @@ enum guild_update_column {
 
   """column name"""
   name
-
-  """column name"""
-  position
 
   """column name"""
   profileLayout
@@ -2425,177 +2414,6 @@ input GuildInfoInput {
 input GuildLayoutInfoInput {
   profileLayout: String!
   uuid: String!
-}
-
-"""
-columns and relationships of "GuildPosition"
-"""
-type GuildPosition {
-  position: String!
-}
-
-"""
-aggregated selection of "GuildPosition"
-"""
-type GuildPosition_aggregate {
-  aggregate: GuildPosition_aggregate_fields
-  nodes: [GuildPosition!]!
-}
-
-"""
-aggregate fields of "GuildPosition"
-"""
-type GuildPosition_aggregate_fields {
-  count(columns: [GuildPosition_select_column!], distinct: Boolean): Int
-  max: GuildPosition_max_fields
-  min: GuildPosition_min_fields
-}
-
-"""
-order by aggregate values of table "GuildPosition"
-"""
-input GuildPosition_aggregate_order_by {
-  count: order_by
-  max: GuildPosition_max_order_by
-  min: GuildPosition_min_order_by
-}
-
-"""
-input type for inserting array relation for remote table "GuildPosition"
-"""
-input GuildPosition_arr_rel_insert_input {
-  data: [GuildPosition_insert_input!]!
-  on_conflict: GuildPosition_on_conflict
-}
-
-"""
-Boolean expression to filter rows from the table "GuildPosition". All fields are combined with a logical 'AND'.
-"""
-input GuildPosition_bool_exp {
-  _and: [GuildPosition_bool_exp]
-  _not: GuildPosition_bool_exp
-  _or: [GuildPosition_bool_exp]
-  position: String_comparison_exp
-}
-
-"""
-unique or primary key constraints on table "GuildPosition"
-"""
-enum GuildPosition_constraint {
-  """unique or primary key constraint"""
-  GuildPosition_pkey
-}
-
-enum GuildPosition_enum {
-  EXTERNAL
-  INTERNAL
-}
-
-"""
-expression to compare columns of type GuildPosition_enum. All fields are combined with logical 'AND'.
-"""
-input GuildPosition_enum_comparison_exp {
-  _eq: GuildPosition_enum
-  _in: [GuildPosition_enum!]
-  _is_null: Boolean
-  _neq: GuildPosition_enum
-  _nin: [GuildPosition_enum!]
-}
-
-"""
-input type for inserting data into table "GuildPosition"
-"""
-input GuildPosition_insert_input {
-  position: String
-}
-
-"""aggregate max on columns"""
-type GuildPosition_max_fields {
-  position: String
-}
-
-"""
-order by max() on columns of table "GuildPosition"
-"""
-input GuildPosition_max_order_by {
-  position: order_by
-}
-
-"""aggregate min on columns"""
-type GuildPosition_min_fields {
-  position: String
-}
-
-"""
-order by min() on columns of table "GuildPosition"
-"""
-input GuildPosition_min_order_by {
-  position: order_by
-}
-
-"""
-response of any mutation on the table "GuildPosition"
-"""
-type GuildPosition_mutation_response {
-  """number of affected rows by the mutation"""
-  affected_rows: Int!
-
-  """data of the affected rows by the mutation"""
-  returning: [GuildPosition!]!
-}
-
-"""
-input type for inserting object relation for remote table "GuildPosition"
-"""
-input GuildPosition_obj_rel_insert_input {
-  data: GuildPosition_insert_input!
-  on_conflict: GuildPosition_on_conflict
-}
-
-"""
-on conflict condition type for table "GuildPosition"
-"""
-input GuildPosition_on_conflict {
-  constraint: GuildPosition_constraint!
-  update_columns: [GuildPosition_update_column!]!
-  where: GuildPosition_bool_exp
-}
-
-"""
-ordering options when selecting data from "GuildPosition"
-"""
-input GuildPosition_order_by {
-  position: order_by
-}
-
-"""
-primary key columns input for table: "GuildPosition"
-"""
-input GuildPosition_pk_columns_input {
-  position: String!
-}
-
-"""
-select columns of table "GuildPosition"
-"""
-enum GuildPosition_select_column {
-  """column name"""
-  position
-}
-
-"""
-input type for updating data in table "GuildPosition"
-"""
-input GuildPosition_set_input {
-  position: String
-}
-
-"""
-update columns of table "GuildPosition"
-"""
-enum GuildPosition_update_column {
-  """column name"""
-  position
 }
 
 """
@@ -3241,19 +3059,6 @@ type mutation_root {
   delete_ExplorerType_by_pk(id: Int!): ExplorerType
 
   """
-  delete data from the table: "GuildPosition"
-  """
-  delete_GuildPosition(
-    """filter the rows which have to be deleted"""
-    where: GuildPosition_bool_exp!
-  ): GuildPosition_mutation_response
-
-  """
-  delete single row from the table: "GuildPosition"
-  """
-  delete_GuildPosition_by_pk(position: String!): GuildPosition
-
-  """
   delete data from the table: "GuildStatus"
   """
   delete_GuildStatus(
@@ -3612,28 +3417,6 @@ type mutation_root {
     """on conflict condition"""
     on_conflict: ExplorerType_on_conflict
   ): ExplorerType
-
-  """
-  insert data into the table: "GuildPosition"
-  """
-  insert_GuildPosition(
-    """the rows to be inserted"""
-    objects: [GuildPosition_insert_input!]!
-
-    """on conflict condition"""
-    on_conflict: GuildPosition_on_conflict
-  ): GuildPosition_mutation_response
-
-  """
-  insert a single row into the table: "GuildPosition"
-  """
-  insert_GuildPosition_one(
-    """the row to be inserted"""
-    object: GuildPosition_insert_input!
-
-    """on conflict condition"""
-    on_conflict: GuildPosition_on_conflict
-  ): GuildPosition
 
   """
   insert data into the table: "GuildStatus"
@@ -4237,26 +4020,6 @@ type mutation_root {
     _set: ExplorerType_set_input
     pk_columns: ExplorerType_pk_columns_input!
   ): ExplorerType
-
-  """
-  update data of the table: "GuildPosition"
-  """
-  update_GuildPosition(
-    """sets the columns of the filtered rows to the given values"""
-    _set: GuildPosition_set_input
-
-    """filter the rows which have to be updated"""
-    where: GuildPosition_bool_exp!
-  ): GuildPosition_mutation_response
-
-  """
-  update single row of the table: "GuildPosition"
-  """
-  update_GuildPosition_by_pk(
-    """sets the columns of the filtered rows to the given values"""
-    _set: GuildPosition_set_input
-    pk_columns: GuildPosition_pk_columns_input!
-  ): GuildPosition
 
   """
   update data of the table: "GuildStatus"
@@ -7480,49 +7243,6 @@ type query_root {
 
   """fetch data from the table: "ExplorerType" using primary key columns"""
   ExplorerType_by_pk(id: Int!): ExplorerType
-
-  """
-  fetch data from the table: "GuildPosition"
-  """
-  GuildPosition(
-    """distinct select on columns"""
-    distinct_on: [GuildPosition_select_column!]
-
-    """limit the number of rows returned"""
-    limit: Int
-
-    """skip the first n rows. Use only with order_by"""
-    offset: Int
-
-    """sort the rows by one or more columns"""
-    order_by: [GuildPosition_order_by!]
-
-    """filter the rows returned"""
-    where: GuildPosition_bool_exp
-  ): [GuildPosition!]!
-
-  """
-  fetch aggregated fields from the table: "GuildPosition"
-  """
-  GuildPosition_aggregate(
-    """distinct select on columns"""
-    distinct_on: [GuildPosition_select_column!]
-
-    """limit the number of rows returned"""
-    limit: Int
-
-    """skip the first n rows. Use only with order_by"""
-    offset: Int
-
-    """sort the rows by one or more columns"""
-    order_by: [GuildPosition_order_by!]
-
-    """filter the rows returned"""
-    where: GuildPosition_bool_exp
-  ): GuildPosition_aggregate!
-
-  """fetch data from the table: "GuildPosition" using primary key columns"""
-  GuildPosition_by_pk(position: String!): GuildPosition
 
   """
   fetch data from the table: "GuildStatus"
@@ -11110,49 +10830,6 @@ type subscription_root {
 
   """fetch data from the table: "ExplorerType" using primary key columns"""
   ExplorerType_by_pk(id: Int!): ExplorerType
-
-  """
-  fetch data from the table: "GuildPosition"
-  """
-  GuildPosition(
-    """distinct select on columns"""
-    distinct_on: [GuildPosition_select_column!]
-
-    """limit the number of rows returned"""
-    limit: Int
-
-    """skip the first n rows. Use only with order_by"""
-    offset: Int
-
-    """sort the rows by one or more columns"""
-    order_by: [GuildPosition_order_by!]
-
-    """filter the rows returned"""
-    where: GuildPosition_bool_exp
-  ): [GuildPosition!]!
-
-  """
-  fetch aggregated fields from the table: "GuildPosition"
-  """
-  GuildPosition_aggregate(
-    """distinct select on columns"""
-    distinct_on: [GuildPosition_select_column!]
-
-    """limit the number of rows returned"""
-    limit: Int
-
-    """skip the first n rows. Use only with order_by"""
-    offset: Int
-
-    """sort the rows by one or more columns"""
-    order_by: [GuildPosition_order_by!]
-
-    """filter the rows returned"""
-    where: GuildPosition_bool_exp
-  ): GuildPosition_aggregate!
-
-  """fetch data from the table: "GuildPosition" using primary key columns"""
-  GuildPosition_by_pk(position: String!): GuildPosition
 
   """
   fetch data from the table: "GuildStatus"


### PR DESCRIPTION
## Overview

**What features/fixes does this PR include?**
As part of the 1.0 push, @dan13ram quickly and effectively implemented guild sorting, but admitted it was a bit of a hack where the guild order was hardcoded into a React component.

This PR adds a `guildPosition` column to the guild table. We can then set the guild positions directly in the database once this goes to prod.

I decided not to include a migration that would actually set the guild ordering, since only our prod environment needs it.