### PR TITLE
Disable arrows when submit proof modal is open

### DIFF
--- a/packages/web/components/Carousel/CarouselContext.tsx
+++ b/packages/web/components/Carousel/CarouselContext.tsx
@@ -9,6 +9,9 @@ type CarouselContextType = {
   isDragging: boolean;
   setDragging: React.Dispatch<React.SetStateAction<boolean>>;
 
+  isSubmittingProof: boolean;
+  setIsSubmittingProof: React.Dispatch<React.SetStateAction<boolean>>;
+
   positions: number[];
   itemWidth: number;
   constraint: number;
@@ -25,6 +28,8 @@ export const CarouselContext = createContext<CarouselContextType>({
   setTrackIsActive: () => undefined,
   activeItem: 0,
   setActiveItem: () => undefined,
+  isSubmittingProof: false,
+  setIsSubmittingProof: () => undefined,
   isDragging: false,
   setDragging: () => undefined,
   sliderWidth: 0,

--- a/packages/web/components/Carousel/Track.tsx
+++ b/packages/web/components/Carousel/Track.tsx
@@ -24,6 +24,7 @@ export const Track: React.FC = ({ children }) => {
     setDragging,
     setTrackIsActive,
     trackIsActive,
+    isSubmittingProof,
     setActiveItem,
     activeItem,
     constraint,
@@ -31,6 +32,7 @@ export const Track: React.FC = ({ children }) => {
     itemWidth,
     positions,
   } = useCarouselContext();
+
   const [dragStartPosition, setDragStartPosition] = useState(0);
   const controls = useAnimation();
   const x = useMotionValue(0);
@@ -104,7 +106,7 @@ export const Track: React.FC = ({ children }) => {
 
   const handleKeyDown = useCallback(
     (event: KeyboardEvent) => {
-      if (trackIsActive) {
+      if (trackIsActive && !isSubmittingProof) {
         if (activeItem < positions.length - constraint) {
           if (event.key === 'ArrowRight' || event.key === 'ArrowUp') {
             event.preventDefault();
@@ -119,7 +121,14 @@ export const Track: React.FC = ({ children }) => {
         }
       }
     },
-    [trackIsActive, setActiveItem, activeItem, constraint, positions.length],
+    [
+      trackIsActive,
+      isSubmittingProof,
+      activeItem,
+      positions.length,
+      constraint,
+      setActiveItem,
+    ],
   );
 
   useEffect(() => {

--- a/packages/web/components/Carousel/index.tsx
+++ b/packages/web/components/Carousel/index.tsx
@@ -11,6 +11,7 @@ export const Carousel: React.FC<{ gap: number; children: JSX.Element[] }> = ({
   gap,
 }) => {
   const [trackIsActive, setTrackIsActive] = useState(false);
+  const [isSubmittingProof, setIsSubmittingProof] = useState(false);
   const [activeItem, setActiveItem] = useState(0);
   const [isDragging, setDragging] = useState(false);
   const [multiplier, setMultiplier] = useState(0.35);
@@ -50,6 +51,8 @@ export const Carousel: React.FC<{ gap: number; children: JSX.Element[] }> = ({
         trackIsActive,
         setTrackIsActive,
         activeItem,
+        isSubmittingProof,
+        setIsSubmittingProof,
         setActiveItem,
         isDragging,
         setDragging,

--- a/packages/web/components/QuestChain/UploadProof.tsx
+++ b/packages/web/components/QuestChain/UploadProof.tsx
@@ -19,6 +19,7 @@ import {
   UseToastOptions,
 } from '@metafam/ds';
 import { contracts, graphql, helpers } from '@quest-chains/sdk';
+import { useCarouselContext } from 'components/Carousel/CarouselContext';
 import { useWeb3 } from 'lib/hooks';
 import { useDropFiles, useDropImage } from 'lib/hooks/useDropFiles';
 import { useInputText } from 'lib/hooks/useInputText';
@@ -43,6 +44,8 @@ export const UploadProof: React.FC<{
 }> = ({ refresh, questId, name, questChain }) => {
   const { chainId, provider, address } = useWeb3();
   const { isOpen, onOpen, onClose } = useDisclosure();
+
+  const { setIsSubmittingProof } = useCarouselContext();
 
   const toast = useToast();
   const toastIdRef = useRef<ToastId | undefined>(undefined);
@@ -74,7 +77,14 @@ export const UploadProof: React.FC<{
     onResetFiles();
     onResetImage();
     onClose();
-  }, [onClose, onResetFiles, onResetImage, setProofDescription]);
+    setIsSubmittingProof(false);
+  }, [
+    onClose,
+    onResetFiles,
+    onResetImage,
+    setIsSubmittingProof,
+    setProofDescription,
+  ]);
 
   const onSubmit = useCallback(async () => {
     if (
@@ -181,7 +191,10 @@ export const UploadProof: React.FC<{
         isDisabled={chainId === questChain.chainId}
       >
         <StatusedSubmitButton
-          onClick={onOpen}
+          onClick={() => {
+            setIsSubmittingProof(true);
+            onOpen();
+          }}
           status={null}
           isDisabled={chainId !== questChain.chainId || !address}
           borderWidth={1}

--- a/packages/web/components/QuestChain/UploadProof.tsx
+++ b/packages/web/components/QuestChain/UploadProof.tsx
@@ -73,18 +73,11 @@ export const UploadProof: React.FC<{
   const { imageFile, onResetImage } = dropImageProps;
 
   const onModalClose = useCallback(() => {
-    setProofDescription('');
     onResetFiles();
     onResetImage();
     onClose();
     setIsSubmittingProof(false);
-  }, [
-    onClose,
-    onResetFiles,
-    onResetImage,
-    setIsSubmittingProof,
-    setProofDescription,
-  ]);
+  }, [onClose, onResetFiles, onResetImage, setIsSubmittingProof]);
 
   const onSubmit = useCallback(async () => {
     if (

--- a/packages/web/components/QuestChain/UploadProof.tsx
+++ b/packages/web/components/QuestChain/UploadProof.tsx
@@ -66,18 +66,16 @@ export const UploadProof: React.FC<{
 
   const dropFilesProps = useDropFiles();
 
-  const { files, onResetFiles } = dropFilesProps;
+  const { files } = dropFilesProps;
 
   const dropImageProps = useDropImage();
 
-  const { imageFile, onResetImage } = dropImageProps;
+  const { imageFile } = dropImageProps;
 
   const onModalClose = useCallback(() => {
-    onResetFiles();
-    onResetImage();
     onClose();
     setIsSubmittingProof(false);
-  }, [onClose, onResetFiles, onResetImage, setIsSubmittingProof]);
+  }, [onClose, setIsSubmittingProof]);
 
   const onSubmit = useCallback(async () => {
     if (
@@ -161,17 +159,20 @@ export const UploadProof: React.FC<{
     setSubmitting(false);
   }, [
     chainId,
-    questChain,
+    questChain.chainId,
+    questChain.name,
+    questChain.address,
+    questChain.version,
+    provider,
     proofDescRef,
+    addToast,
     files,
     imageFile,
     questId,
     name,
+    address,
     onModalClose,
     refresh,
-    address,
-    provider,
-    addToast,
   ]);
 
   return (


### PR DESCRIPTION
the arrows will still move the cursor correctly

## Overview

**What features/fixes does this PR include?**

When the submit proof modal is open, we disabled arrow button functionality which navigates the user between quests.

**Please provide the GitHub issue number**

Closes #1424 

## Implementation

I made a flag which is set to `true` if the modal is open and `false` if it's closed & added it to the CarouselContext.