### PR TITLE
Show all the patrons on the patrons page (1417) (v2)

### DIFF
--- a/packages/design-system/src/index.ts
+++ b/packages/design-system/src/index.ts
@@ -204,6 +204,7 @@ export {
   usePrefersReducedMotion,
   useTheme,
   useToast,
+  VisuallyHidden,
   VStack,
   Wrap,
   WrapItem,

--- a/packages/web/pages/patrons.tsx
+++ b/packages/web/pages/patrons.tsx
@@ -1,9 +1,18 @@
+import {
+  ArrowUpIcon,
+  Box,
+  Button,
+  Image,
+  VisuallyHidden,
+  VStack,
+} from '@metafam/ds';
+import Octopus from 'assets/octopus.png';
 import { PageContainer } from 'components/Container';
 import { PatronList } from 'components/Patron/PatronList';
 import { HeadComponent } from 'components/Seo';
 import { getPatrons, getPSeedPrice } from 'graphql/getPatrons';
 import { InferGetStaticPropsType } from 'next';
-import React from 'react';
+import React, { useRef } from 'react';
 
 type Props = InferGetStaticPropsType<typeof getStaticProps>;
 
@@ -22,15 +31,52 @@ export const getStaticProps = async () => {
   };
 };
 
-const PatronsPage: React.FC<Props> = ({ patrons, pSeedPrice }) => (
-  <PageContainer>
-    <HeadComponent
-      title="MetaGame Patrons"
-      description="MetaGame is a Massive Online Coordination Game! MetaGame’s Patrons enable us to succeed by helping us with funds."
-      url="https://my.metagame.wtf/patrons"
-    />
-    <PatronList {...{ patrons, pSeedPrice }} />
-  </PageContainer>
-);
+const PatronsPage: React.FC<Props> = ({ patrons, pSeedPrice }) => {
+  /**
+   * For the back to top link
+   */
+  const topRef = useRef<HTMLHeadingElement>(null);
+  function handleBackClick() {
+    topRef?.current?.scrollIntoView({ behavior: 'smooth' });
+  }
 
+  return (
+    <PageContainer>
+      <HeadComponent
+        title="MetaGame Patrons"
+        description="MetaGame is a Massive Online Coordination Game! MetaGame’s Patrons enable us to succeed by helping us with funds."
+        url="https://my.metagame.wtf/patrons"
+      />
+
+      {/* This is mostly here as a placeholder for the back to top link, but screenreaders will read out the heading
+       * It is set as="h1" b/c the Chakra library VisuallyHidden component is a span by default
+       */}
+      <VisuallyHidden as="h1" ref={topRef}>
+        Patrons of MetaGame
+      </VisuallyHidden>
+
+      {/* VStack is used to make a consistent gap between the Patrons list, and the Octo image and back to top link */}
+      <VStack maxW="7xl" w="100%" spacing={{ base: 4, md: 8 }}>
+        <PatronList {...{ patrons, pSeedPrice }} />
+
+        {/* Back to top link */}
+        <Image src={Octopus.src} pt={8} />
+
+        <Box pb={4}>
+          <Button
+            leftIcon={<ArrowUpIcon />}
+            variant="ghost"
+            color="whiteAlpha.700"
+            bgColor="whiteAlpha.50"
+            _hover={{ bg: 'whiteAlpha.200' }}
+            _active={{ bg: 'whiteAlpha.200' }}
+            onClick={handleBackClick}
+          >
+            Back to top
+          </Button>
+        </Box>
+      </VStack>
+    </PageContainer>
+  );
+};
 export default PatronsPage;

--- a/packages/web/pages/patrons.tsx
+++ b/packages/web/pages/patrons.tsx
@@ -3,6 +3,9 @@ import {
   Box,
   Button,
   Image,
+  MetaButton,
+  Text,
+  Tooltip,
   VisuallyHidden,
   VStack,
 } from '@metafam/ds';
@@ -12,12 +15,17 @@ import { PatronList } from 'components/Patron/PatronList';
 import { HeadComponent } from 'components/Seo';
 import { getPatrons, getPSeedPrice } from 'graphql/getPatrons';
 import { InferGetStaticPropsType } from 'next';
-import React, { useRef } from 'react';
+import React, { useRef, useState } from 'react';
 
 type Props = InferGetStaticPropsType<typeof getStaticProps>;
 
 export const getStaticProps = async () => {
-  const patrons = await getPatrons();
+  /**
+   * Get all the Patrons
+   * (MetaGame rules say there can be 150 max, so we'll limit the query to that many)
+   */
+  const patronsLimit = 150;
+  const patrons = await getPatrons(patronsLimit);
   const pSeedPrice = await getPSeedPrice().catch((error) => {
     console.error('Error fetching pSeed price', error);
     return null;
@@ -40,6 +48,67 @@ const PatronsPage: React.FC<Props> = ({ patrons, pSeedPrice }) => {
     topRef?.current?.scrollIntoView({ behavior: 'smooth' });
   }
 
+  /**
+   * Settings for the Load More patrons button
+   */
+  /* How many patrons were found, in total? */
+  const totalItems = patrons.length;
+
+  /* How many patrons to show initially, and how many more to load each time the Load More button is clicked? */
+  const showHowMany = 30;
+
+  /* How many Patrons are visible right now? */
+  const [visible, setVisible] = useState(showHowMany);
+
+  /* Increment the number visible by `showHowMany` when the Load More button is clicked */
+  const handleShowMoreItems = () => {
+    setVisible((prevValue) => prevValue + showHowMany);
+  };
+
+  /**
+   * Print out the Load More button
+   * If there are no more patrons to load, disable the button and add a tooltip that says 'no more to load'
+   */
+  function renderLoadMoreButton() {
+    const buttonStyles = {
+      minW: '10rem',
+    };
+
+    if (visible < totalItems) {
+      /* When there are more items to show */
+      return (
+        <MetaButton onClick={handleShowMoreItems} {...buttonStyles}>
+          Load more
+        </MetaButton>
+      );
+    }
+
+    /* When there are no more items to show */
+    return (
+      <Tooltip label="No more to load" aria-label="A tooltip">
+        <MetaButton as="span" isDisabled {...buttonStyles}>
+          Load more
+        </MetaButton>
+      </Tooltip>
+    );
+  }
+
+  /**
+   * Print text 'Showing X of Y items'
+   * if X (visible items) is greater than Y (total items), then just print Y of Y
+   * (or X could overflow and print 60 of 43)
+   */
+  function renderShowingXOfYItems() {
+    const showingXOf = visible >= totalItems ? totalItems : visible;
+    const showingYOf = totalItems;
+
+    return (
+      <Text>
+        Showing {showingXOf} of {showingYOf} patrons
+      </Text>
+    );
+  }
+
   return (
     <PageContainer>
       <HeadComponent
@@ -55,9 +124,18 @@ const PatronsPage: React.FC<Props> = ({ patrons, pSeedPrice }) => {
         Patrons of MetaGame
       </VisuallyHidden>
 
-      {/* VStack is used to make a consistent gap between the Patrons list, and the Octo image and back to top link */}
+      {/* VStack is used to make a consistent gap between the Patrons list, the Load More button, the X of Y patrons text, and the Octo image and back to top link */}
       <VStack maxW="7xl" w="100%" spacing={{ base: 4, md: 8 }}>
-        <PatronList {...{ patrons, pSeedPrice }} />
+        <PatronList
+          patrons={patrons.slice(0, visible)}
+          pSeedPrice={pSeedPrice}
+        />
+
+        {/* Load More button */}
+        {renderLoadMoreButton()}
+
+        {/* Showing X of Y patrons text */}
+        {renderShowingXOfYItems()}
 
         {/* Back to top link */}
         <Image src={Octopus.src} pt={8} />


### PR DESCRIPTION
Re-doing this PR because I messed up the commit history on [the previous PR](https://github.com/MetaFam/TheGame/pull/1439).

## Overview

**What features/fixes does this PR include?**

**1. only 48 patrons shown**  
> When you scroll down to the bottom of the patrons leaderboard, its not loading any more than the first 48.  

Now loads all the patrons (max 150) and displays them in sets of 30, with a Load More button to show the next 30 patrons.

**2. Cards go all the way to the bottom of the screen**  
> patron cards go all the way to the edge of the screen instead of there being a margin.  

Added a back to top link at the bottom to provide a margin between cards and edge of the screen

**Please provide the GitHub issue number**
Closes #1417 

## Implementation

**Showing all the patrons part**  
- getPatrons query set to retrieve 150 patrons
- Standard (?) ‘load more’ button based on various Google results
- Load more button is disabled when there are no more patrons to display
- Below the Load More button it shows a count of patrons, so people can see how many times to click before they'll be at the end
- More comments (maybe too many) in the code

**Back to top link**  
- Copied it from other pages
- The patrons page doesn't have a heading to use as a ref for the back-to-top target, so I added a heading that is not shown on the screen (Chakra's VisuallyHidden component)

**Describe technical (nontrivial / non-obvious) parts of your code**
- Added the VisuallyHidden component to the design system import

**Side effects**
- There's a [branch and a linked PR](https://github.com/MetaFam/TheGame/pull/1439) that I'm going to withdraw in favour of this one.


## Assets

Load more button and etc  👇
![image](https://user-images.githubusercontent.com/92962228/200276497-c2373878-2357-4b83-89e5-30a48d13867f.png)

Load more button disabled, with tool tip 👇
![image](https://user-images.githubusercontent.com/92962228/200276585-3b475988-8fc7-494a-8681-8ab762e14ec0.png)
