### PR TITLE
Use consistent underlying images for all docker containers

### DIFF
--- a/docker/backend/Dockerfile
+++ b/docker/backend/Dockerfile
@@ -43,7 +43,7 @@ RUN yarn backend:build
 RUN yarn install --pure-lockfile --production --ignore-scripts --prefer-offline
 
 # Create completely new stage including only necessary files
-FROM node:16-alpine as app
+FROM node:16-slim as app
 WORKDIR /app
 
 # Copy necessary files into the stage

--- a/docker/discord-bot/Dockerfile
+++ b/docker/discord-bot/Dockerfile
@@ -38,7 +38,7 @@ RUN yarn discord-bot build
 RUN yarn install --pure-lockfile --production --ignore-scripts --prefer-offline
 
 # Create completely new stage including only necessary files
-FROM node:16-alpine as app
+FROM node:16-slim as app
 WORKDIR /app
 
 # Needed at runtime

--- a/docker/frontend/Dockerfile
+++ b/docker/frontend/Dockerfile
@@ -50,7 +50,7 @@ RUN yarn web:build
 RUN yarn install --pure-lockfile --production --ignore-scripts --prefer-offline
 
 # Create completely new stage including only necessary files
-FROM node:16-alpine as app
+FROM node:16-slim as app
 WORKDIR /app
 
 # Copy necessary files into the stage


### PR DESCRIPTION
We have been building all our docker containers using the image 
`FROM node:16-slim as base`
but when we deploy we use
`FROM node:16-alpine as app`
and then just copy over the files.  This can cause runtime errors due to the underlying environment being different.