### PR TITLE
Fixing Cropping of Filter Options

### DIFF
--- a/packages/web/components/Player/Filter/DesktopFilters.tsx
+++ b/packages/web/components/Player/Filter/DesktopFilters.tsx
@@ -68,10 +68,10 @@ export const DesktopFilters: React.FC<Props> = ({
 
   return (
     <Wrap
+      ref={filterRef}
       transition="all 0.25s"
       py={6}
-      style={{ backdropFilter: 'blur(7px)' }}
-      ref={filterRef}
+      backdropFilter="blur(7px)"
       position="sticky"
       top="-1px"
       borderTop="1px solid transparent"
@@ -81,7 +81,8 @@ export const DesktopFilters: React.FC<Props> = ({
       maxW={isSticky ? 'auto' : '79rem'}
       bg={isSticky ? 'purpleTag70' : 'whiteAlpha.200'}
       px={isSticky ? '4.5rem' : '1.5rem'}
-      borderRadius={isSticky ? '0px' : '6px'}
+      borderRadius={isSticky ? 0 : '6px'}
+      overflow="visible" // Wrap defaults to hidden
       {...props}
     >
       <WrapItem>

--- a/packages/web/components/Player/PlayerList.tsx
+++ b/packages/web/components/Player/PlayerList.tsx
@@ -16,6 +16,7 @@ export const PlayerList: React.FC<Props> = ({
     columns={[1, null, 2, 3]}
     spacing={8}
     autoRows="minmax(35rem, auto)"
+    w="full"
   >
     {players.map((player, idx) => (
       <PlayerTile

--- a/packages/web/components/Quest/QuestFilter.tsx
+++ b/packages/web/components/Quest/QuestFilter.tsx
@@ -1,4 +1,5 @@
 import {
+  Flex,
   FormControl,
   FormLabel,
   MetaFilterSelectSearch,
@@ -91,112 +92,122 @@ export const QuestFilter: React.FC<Props> = ({
   const [roles, setRoles] = useState<FilterString[]>([]);
 
   return (
-    <Wrap justifyContent="center">
+    <Flex direction="column">
       <Wrap
         transition="all 0.25s"
-        style={{ backdropFilter: 'blur(7px)' }}
+        backdropFilter="blur(7px)"
         position="sticky"
         top="-1px"
         borderTop="1px solid transparent"
         zIndex={1}
         justifyContent="center"
-        w="100%"
         maxW="79rem"
         bg="whiteAlpha.200"
         px="1.5rem"
         py={6}
         borderRadius="6px"
+        overflow="visible"
       >
-        <MetaFilterSelectSearch
-          title={`Limit: ${limit.label}`}
-          styles={metaFilterSelectStyles}
-          hasValue={false}
-          value={limit}
-          onChange={(value) => {
-            const values = value as FilterString[];
-            const [v] = values.slice(-1);
-            if (v) {
-              setLimit(v);
-              setQueryVariable('limit', Number(v.value));
-            }
-          }}
-          options={limitOptions}
-          disableEmpty
-        />
-        <MetaFilterSelectSearch
-          title={`Order: ${order.label}`}
-          styles={metaFilterSelectStyles}
-          hasValue={false}
-          value={order}
-          onChange={(value) => {
-            const values = value as FilterString[];
-            const [o] = values.slice(-1);
-            if (o) {
-              setOrder(o);
-              setQueryVariable('order', o.value);
-            }
-          }}
-          options={orderOptions}
-          disableEmpty
-        />
-        <MetaFilterSelectSearch
-          title={`Status: ${status.label}`}
-          styles={metaFilterSelectStyles}
-          hasValue={false}
-          value={status}
-          onChange={(value) => {
-            const values = value as FilterString[];
-            const [s] = values.slice(-1);
-            if (s) {
-              setStatus(s);
-              setQueryVariable('status', s.value);
-            }
-          }}
-          options={statusOptions}
-          disableEmpty
-        />
-        {aggregates.guilds.length ? (
+        <WrapItem>
           <MetaFilterSelectSearch
-            title={`Guild: ${guild.label}`}
+            title={`Limit: ${limit.label}`}
             styles={metaFilterSelectStyles}
             hasValue={false}
-            value={guild}
+            value={limit}
             onChange={(value) => {
               const values = value as FilterString[];
-              const [g] = values.slice(-1);
-              if (g) {
-                setGuild(g);
-                setQueryVariable('guildId', g.value);
+              const [v] = values.slice(-1);
+              if (v) {
+                setLimit(v);
+                setQueryVariable('limit', Number(v.value));
               }
             }}
-            options={guildOptions}
+            options={limitOptions}
             disableEmpty
           />
-        ) : null}
-        {roleChoices.length && (
+        </WrapItem>
+        <WrapItem>
           <MetaFilterSelectSearch
-            title="Roles"
+            title={`Order: ${order.label}`}
             styles={metaFilterSelectStyles}
             hasValue={false}
-            value={roles}
+            value={order}
             onChange={(value) => {
               const values = value as FilterString[];
-              const selectedRoles = values;
+              const [o] = values.slice(-1);
+              if (o) {
+                setOrder(o);
+                setQueryVariable('order', o.value);
+              }
+            }}
+            options={orderOptions}
+            disableEmpty
+          />
+        </WrapItem>
+        <WrapItem>
+          <MetaFilterSelectSearch
+            title={`Status: ${status.label}`}
+            styles={metaFilterSelectStyles}
+            hasValue={false}
+            value={status}
+            onChange={(value) => {
+              const values = value as FilterString[];
+              const [s] = values.slice(-1);
+              if (s) {
+                setStatus(s);
+                setQueryVariable('status', s.value);
+              }
+            }}
+            options={statusOptions}
+            disableEmpty
+          />
+        </WrapItem>
+        {aggregates.guilds.length > 0 && (
+          <WrapItem>
+            <MetaFilterSelectSearch
+              title={`Guild: ${guild.label}`}
+              styles={metaFilterSelectStyles}
+              hasValue={false}
+              value={guild}
+              onChange={(value) => {
+                const values = value as FilterString[];
+                const [g] = values.slice(-1);
+                if (g) {
+                  setGuild(g);
+                  setQueryVariable('guildId', g.value);
+                }
+              }}
+              options={guildOptions}
+              disableEmpty
+            />
+          </WrapItem>
+        )}
+        {roleChoices.length > 0 && (
+          <WrapItem>
+            <MetaFilterSelectSearch
+              title="Roles"
+              styles={metaFilterSelectStyles}
+              hasValue={false}
+              value={roles}
+              onChange={(value) => {
+                const values = value as FilterString[];
+                const selectedRoles = values;
 
-              if (selectedRoles.length) {
-                setRoles(selectedRoles);
-                setQueryVariable(
-                  'questRoles',
-                  selectedRoles.map((x) => x.value),
-                );
-              } else {
-                setRoles([]);
-                setQueryVariable('questRoles', '');
-              }
-            }}
-            options={roleOptions}
-            disableEmpty
-          />
+                if (selectedRoles.length) {
+                  setRoles(selectedRoles);
+                  setQueryVariable(
+                    'questRoles',
+                    selectedRoles.map((x) => x.value),
+                  );
+                } else {
+                  setRoles([]);
+                  setQueryVariable('questRoles', '');
+                }
+              }}
+              options={roleOptions}
+              disableEmpty
+            />
+          </WrapItem>
         )}
         {myId && (
           <WrapItem
@@ -228,13 +239,7 @@ export const QuestFilter: React.FC<Props> = ({
           </WrapItem>
         )}
       </Wrap>
-      {quests && (
-        <WrapItem>
-          <Text align="center" fontWeight="bold">
-            {quests.length} quests
-          </Text>
-        </WrapItem>
-      )}
-    </Wrap>
+      {quests && <Text fontWeight="bold">{quests.length} quests</Text>}
+    </Flex>
   );
 };


### PR DESCRIPTION
## Overview

**What features/fixes does this PR include?**

`Wrap` components, by default, set `overflow` to `hidden`. This PR sets `overflow` to `visible` for the containers of the filters so they aren't cropped.

Also, it switches the outer `Wrap` in the `QuestFilter` to a `Flex`, and puts the children of the inner `Wrap` in `WrapItem`s since `Wrap` generates a `ul` & it was full of `div`s.

Closes #1474 & #1468.

## Follow Up Improvement Ideas

This is a fairly targeted PR. I specifically avoided syntactic fixes because I wanted to avoid conflicts with #1461.