### PR TITLE
Some minor updates to guild join flow

### DIFF
--- a/packages/backend/src/config.ts
+++ b/packages/backend/src/config.ts
@@ -7,6 +7,7 @@ interface IConfig {
   nodeEnv: string;
   graphqlURL: string;
   frontendURL: string;
+  hasuraAdminURL: string;
   daoHausGraphqlURL: string;
   daoHausPolygonGraphqlURL: string;
   daoHausXdaiGraphqlURL: string;
@@ -45,6 +46,10 @@ export const CONFIG: IConfig = {
     return 'http://localhost:8080/v1/graphql';
   })(),
   frontendURL: parseEnv(process.env.FRONTEND_URL, 'http://localhost:3000'),
+  hasuraAdminURL: parseEnv(
+    process.env.HASURA_ADMIN_URL,
+    'https://api.metagame.wtf/console',
+  ),
   daoHausGraphqlURL: parseEnv(
     process.env.DAOHAUS_GRAPHQL_URL,
     'https://api.thegraph.com/subgraphs/name/odyssy-automaton/daohaus',

--- a/packages/backend/src/handlers/actions/guild/saveGuildHandler.ts
+++ b/packages/backend/src/handlers/actions/guild/saveGuildHandler.ts
@@ -1,11 +1,19 @@
-import { GuildDiscordMetadata } from '@metafam/discord-bot';
+import {
+  createDiscordClient,
+  GuildDiscordMetadata,
+} from '@metafam/discord-bot';
+import { Constants } from '@metafam/utils';
+import { TextChannel } from 'discord.js';
 import { Request, Response } from 'express';
 
+import { CONFIG } from '../../../config.js';
 import {
   Dao_Player,
   Guild_Set_Input,
   GuildDaoInput,
+  GuildFragment,
   GuildInfoInput,
+  GuildStatus_Enum,
   GuildType_Enum,
 } from '../../../lib/autogen/hasura-sdk.js';
 import { client } from '../../../lib/hasuraClient.js';
@@ -23,17 +31,37 @@ export const saveGuildHandler = async (
   const { input, session_variables: sessionVariables } = req.body;
   const playerId = sessionVariables['x-hasura-user-id'];
 
+  const { guildInformation } = input;
+
+  let updatedGuild: GuildFragment;
   try {
-    const { guildInformation } = input;
-    await saveGuild(playerId, guildInformation as GuildInfoInput);
-    res.json({ success: true });
+    updatedGuild = await saveGuild(
+      playerId,
+      guildInformation as GuildInfoInput,
+    );
   } catch (error) {
     console.error(error);
     res.json({
       success: false,
       error: (error as Error).message,
     });
+    return;
   }
+
+  const isNew = updatedGuild.status === GuildStatus_Enum.Pending;
+
+  if (isNew) {
+    try {
+      await sendDiscordNotification(guildInformation);
+    } catch (error) {
+      console.error(
+        "Error sending notification to Champion's League channel",
+        error,
+      );
+    }
+  }
+
+  res.json({ success: true });
 };
 
 const saveGuild = async (playerId: string, guildInfo: GuildInfoInput) => {
@@ -149,4 +177,21 @@ const saveGuild = async (playerId: string, guildInfo: GuildInfoInput) => {
     guildId: guildInfo.uuid,
     discordMetadata: updatedMetadata,
   });
+
+  const { guild } = await client.GetGuild({ id: guildInfo.uuid });
+  return guild[0];
 };
+
+async function sendDiscordNotification(
+  guildInfo: GuildInfoInput,
+): Promise<void> {
+  const discordClient = await createDiscordClient();
+
+  const targetChannel = (await discordClient.channels.fetch(
+    Constants.METAFAM_DISCORD_CHAMPS_RING_CHANNEL_ID,
+  )) as TextChannel;
+  const link = `${CONFIG.hasuraAdminURL}/data/schema/public/tables/guild/browse?filter=guildname%3B%24eq%3B${guildInfo.guildname}`;
+  targetChannel.send(
+    `A new guild signed up! Name: ${guildInfo.name}  Someone with access to the Hasura instance can approve them here: ${link}`,
+  );
+}

--- a/packages/backend/src/handlers/triggers/playerRankUpdated.ts
+++ b/packages/backend/src/handlers/triggers/playerRankUpdated.ts
@@ -1,12 +1,9 @@
-/* eslint-disable no-console */
 import { createDiscordClient } from '@metafam/discord-bot';
 import { Constants } from '@metafam/utils';
-import { TextChannel } from 'discord.js';
 
 import { CONFIG } from '../../config.js';
 import { PlayerRank_Enum } from '../../lib/autogen/hasura-sdk.js';
 import { client } from '../../lib/hasuraClient.js';
-import { isRankHigher } from '../../lib/rankHelpers.js';
 import { PlayerRow, TriggerPayload } from './types.js';
 
 type RankRoleIds = { [rank in PlayerRank_Enum]: string };
@@ -106,20 +103,25 @@ export const playerRankUpdated = async (payload: TriggerPayload<PlayerRow>) => {
     } else {
       await discordPlayer.roles.add([discordRoleForRank]);
 
+      // Disabling the give-props notification as it tends to get triggered too often due
+      // to an upstream issue: large erroneous shifts in the daily XP calculations from
+      // the daily XP job not receiving all the requisite data
+
       // We should check whether this role is higher than the previous
-      if (isRankHigher(oldPlayer?.rank, newPlayer?.rank)) {
-        try {
-          const propsChannel = (await discordClient.channels.fetch(
-            Constants.METAFAM_DISCORD_PROPS_CHANNEL_ID,
-          )) as TextChannel;
-          propsChannel.send(
-            `Props to ${discordPlayer} for becoming ${newRank}, congrats!`,
-          );
-        } catch (discordError) {
-          console.error('Could not send message to Props channel');
-          console.error(discordError);
-        }
-      }
+      // if (isRankHigher(oldPlayer?.rank, newPlayer?.rank)) {
+      //   try {
+      //     const propsChannel = (await discordClient.channels.fetch(
+      //       Constants.METAFAM_DISCORD_PROPS_CHANNEL_ID,
+      //     )) as TextChannel;
+      //     propsChannel.send(
+      //       `Props to ${discordPlayer} for becoming ${newRank}, congrats!`,
+      //     );
+      //   } catch (discordError) {
+      //     console.error('Could not send message to Props channel');
+      //     console.error(discordError);
+      //   }
+      // }
+
       console.log(`${username}: added role ${newRank}`);
     }
   } catch (e) {

--- a/packages/utils/src/constants.ts
+++ b/packages/utils/src/constants.ts
@@ -7,6 +7,7 @@ export const JOIN_GUILD_DISCORD_OAUTH_SCOPES = 'bot identify';
 export const DISCORD_OAUTH_CALLBACK_PATH = `${WEB_PATH_JOIN_GUILD}/auth`;
 export const METAFAM_DISCORD_GUILD_ID = '629411177947987986';
 export const METAFAM_DISCORD_PROPS_CHANNEL_ID = '718557002221224037';
+export const METAFAM_DISCORD_CHAMPS_RING_CHANNEL_ID = '760181556765130752';
 
 export const SC_OUTPUT_BASE =
   'https://raw.githubusercontent.com/MetaFam/XP/gh-pages/';

--- a/packages/web/components/Guild/GuildForm.tsx
+++ b/packages/web/components/Guild/GuildForm.tsx
@@ -528,7 +528,7 @@ export const GuildForm: React.FC<Props> = ({
             </Box>
           ))}
           <MetaButton size="sm" onClick={() => append(placeholderDaoInput)}>
-            Add {daoFields.length > 0 ? 'another' : 'DAO'}
+            Add {daoFields.length > 0 ? 'Another' : 'a DAO'}
           </MetaButton>
         </Box>
 

--- a/packages/web/components/Guild/GuildForm.tsx
+++ b/packages/web/components/Guild/GuildForm.tsx
@@ -115,9 +115,6 @@ const getDefaultFormValues = (
       label: d.label,
       url: d.url,
     }));
-  } else if (metadata?.discordMetadata?.administratorRoleIds == null) {
-    // Only stub out a DAO if they are going through the guild setup process
-    daos = [placeholderDaoInput];
   }
 
   return {
@@ -421,10 +418,12 @@ export const GuildForm: React.FC<Props> = ({
           borderColor="rgba(255, 255, 255, 0.25)"
           p={4}
         >
-          <Text mb={2}>DAO information</Text>
+          <Text mb={2}>Related DAOs or other contracts</Text>
           <Text fontSize="sm" mb={4}>
-            If your guild has one or more DAOs, enter their information here. If
-            your DAO is in DAOHaus, we will look up its information from the{' '}
+            If your guild has an on-chain DAO, token, multisig, or any other
+            relevant contract, you can specify them here. If the entered
+            contract address is in DAOHaus, we will look up its information from
+            the{' '}
             <MetaLink
               isExternal
               href="https://thegraph.com/hosted-service/subgraph/odyssy-automaton/daohaus"
@@ -529,7 +528,7 @@ export const GuildForm: React.FC<Props> = ({
             </Box>
           ))}
           <MetaButton size="sm" onClick={() => append(placeholderDaoInput)}>
-            Add another
+            Add {daoFields.length > 0 ? 'another' : 'DAO'}
           </MetaButton>
         </Box>
 

--- a/packages/web/pages/join/guild/[guildname].tsx
+++ b/packages/web/pages/join/guild/[guildname].tsx
@@ -69,8 +69,7 @@ const SetupGuild: React.FC = () => {
       if (saveGuildResponse?.success) {
         toast({
           title: 'Guild information submitted',
-          description:
-            'Please allow a few days to review your guild information',
+          description: 'Thanks! Your guild will go live shortly 🚀',
           status: 'success',
           isClosable: true,
           duration: 5000,

--- a/packages/web/pages/join/guild/start.tsx
+++ b/packages/web/pages/join/guild/start.tsx
@@ -64,6 +64,19 @@ const GuildSetupAuthCallback: React.FC = () => {
                 </ListItem>
               </UnorderedList>
             </Text>
+            <Text fontStyle="italic" mt={3}>
+              Wait, why Discord?
+            </Text>
+            <Text mt={2}>
+              Well, turns out that (at this moment anyway) there is no
+              standardized source of truth for determining who is a "member" of
+              a guild. We built an integration with Discord because just about
+              every guild has a Discord server. Most servers use roles to give
+              certain community members additional privileges, which is often a
+              good approximation for "membership". So, by linking your Discord
+              server and telling us what roles determine what, we can determine
+              which MyMeta users are members of your guild!
+            </Text>
             <MetaButton
               size="lg"
               maxW="15rem"
@@ -71,7 +84,7 @@ const GuildSetupAuthCallback: React.FC = () => {
               as="a"
               href={discordAuthURL}
             >
-              Apply to Join
+              Join
             </MetaButton>
           </>
         ) : (


### PR DESCRIPTION
## Overview

See #1472 for context. 

Our new guild onboarding flow requires potential guilds to first fill out a form (externally) to gauge fit.  Once they get over that hurdle, they are sent to the "Join as a Guild" page to submit their information to our database.  This PR:

- adds additional copy about why we require linking with their Discord server
- Removes the default placeholder DAO from the form, as suggested by maxwell 
- On form submission, sends a message to the champions league channel so we don't miss it

Note that I had to explicitly give MetaGameBot the "send message" permission to the champion's league channel within Discord.

`/join/guild/start` is the path for testing
