### PR TITLE
Prevent Title Blurring By `backdrop-filter`

### DIFF
--- a/packages/web/components/Quest/QuestTile.tsx
+++ b/packages/web/components/Quest/QuestTile.tsx
@@ -62,6 +62,7 @@ export const QuestTile: React.FC<Props> = ({ quest }) => {
             <SquareImage src={httpLink(quest.image) ?? BackgroundImage.src} />
             <Flex justify="center" position="absolute" bottom="-15%" w="full">
               <Heading
+                zIndex={3}
                 size="lg"
                 color="white"
                 bgColor="whiteAlpha.300"


### PR DESCRIPTION
## Overview

**What features/fixes does this PR include?**

Increases the `z-index` on the titles of quests to put them above the containing element which has a `blur` `backdrop-filter`.

They go from this:

![Screenshot from 2022-12-12 14-50-41](https://user-images.githubusercontent.com/181523/207141420-b1a5f7aa-8b5e-4f99-b03d-c8e81888695a.png)

To this:

![Screenshot from 2022-12-12 14-55-16](https://user-images.githubusercontent.com/181523/207141552-8672f7a5-5f3e-44bf-a351-30183eacb7fb.png)