### PR TITLE
Remove "MetaGame" from other parties' pages within our site

### DIFF
--- a/packages/backend/package.json
+++ b/packages/backend/package.json
@@ -10,10 +10,10 @@
   "scripts": {
     "start": "node --trace-warnings dist/index.js",
     "build": "yarn generate && tsc -b",
-    "dev": "tsc --build && concurrently \"tsc --watch --preserveWatchOutput\" \"nodemon\" \"yarn generate --watch\"",
+    "dev": "tsc --build && concurrently 'tsc --watch --preserveWatchOutput' nodemon 'yarn generate # --watch'",
     "typecheck": "yarn build",
     "precommit": "yarn lint-staged",
-    "generate": "DEBUG=1 graphql-codegen --config=codegen.yml",
+    "generate": "DEBUG=1 graphql-codegen --config=codegen.yml && export OUT=src/lib/autogen/daohaus-sdk.ts && awk '!/MolochVersion = .molochVersion/' $OUT > $OUT.filtered && mv $OUT.filtered $OUT",
     "lintfix": "eslint --fix",
     "test": "jest --passWithNoTests"
   },

--- a/packages/web/components/QuestChain/UploadImageForm.tsx
+++ b/packages/web/components/QuestChain/UploadImageForm.tsx
@@ -8,6 +8,7 @@ import {
   Image,
   SmallCloseIcon,
 } from '@metafam/ds';
+import { MakeOptional } from 'graphql/autogen/types';
 import { DropImageType } from 'lib/hooks/useDropFiles';
 import { ImageProps } from 'next/image';
 import React from 'react';
@@ -26,7 +27,7 @@ export const UploadImageForm = ({
   label?: string;
   labelColor?: string;
   formControlProps?: FormControlProps;
-  imageProps?: Omit<ImageProps, 'src'> & BoxProps;
+  imageProps?: MakeOptional<Omit<ImageProps, 'src'>, 'alt'> & BoxProps;
 }) => (
   <FormControl {...formControlProps}>
     <FormLabel color={labelColor} htmlFor="imageInput">

--- a/packages/web/pages/guild/[guildname]/index.tsx
+++ b/packages/web/pages/guild/[guildname]/index.tsx
@@ -40,9 +40,9 @@ const GuildPage: React.FC<Props> = ({ guild }) => {
   return (
     <PageContainer p={0}>
       <HeadComponent
-        title={`MetaGame Guild Profile: ${guild.name}`}
+        title={guild.name}
         description={`${(guild.description ?? '').replace('\n', ' ')}`}
-        url={`https://my.metagame.wtf/guild/${guild.guildname}`}
+        url={`https://metagame.wtf/guild/${guild.guildname}`}
         img={`${guild.logo}`}
       />
       <Flex


### PR DESCRIPTION
## Overview

**What features/fixes does this PR include?**

Pages like the Guild overviews include "MetaGame Guild:" at the start of the title. This PR removes that branding to use only the external party's identifier.

**Please provide the GitHub issue number**

Closes #1526.