### PR TITLE
Fix guild membership sync

### DIFF
--- a/packages/web/components/Guild/Section/GuildPlayers.tsx
+++ b/packages/web/components/Guild/Section/GuildPlayers.tsx
@@ -25,7 +25,7 @@ type Props = {
 };
 
 export const GuildPlayers: React.FC<Props> = ({
-  guild: { id: guildId, name: guildname },
+  guild: { id: guildId, guildname },
   editing,
 }) => {
   const { isOpen, onOpen, onClose } = useDisclosure();

--- a/packages/web/components/Landing/UserGrid.tsx
+++ b/packages/web/components/Landing/UserGrid.tsx
@@ -92,7 +92,7 @@ export const UserGrid: React.FC<{
 
     {elders?.map((elder, i) => (
       <Link
-        key={`elders-${i}`}
+        key={`elder-${i}`}
         role="group"
         _hover={{
           textDecoration: 'none',


### PR DESCRIPTION
## Overview

Resolves #1590

## Follow up Improvement Ideas

- [ ] Fix the actual issues in the guilds that the sync is complaining about as well

## Implementation

Changed sync logic to not short-circuit if there are errors

## Assets

New trigger response e.g.
```
{
  "data": {
      "message": "Error syncing Discord guild memberships: Failed to sync 2 guilds:\nError: Quest Chains: Guild Quest Chains has no metadata.\nError: CRΞ8R DAO: Guild CRΞ8R DAO has no metadata.\n\nSuccessfully synced 1 guilds:\nMetaFam"
    },
    "type": "client_error",
    "version": "1"
}
```
