### PR TITLE
Updating "The Academy" to dAcademy

### DIFF
--- a/packages/web/pages/academy/index.tsx
+++ b/packages/web/pages/academy/index.tsx
@@ -45,7 +45,7 @@ const AcademyPage: React.FC = () => {
   return (
     <PageContainer>
       <HeadComponent
-        title="Academy"
+        title="dAcademy"
         description="MetaGame is a Massive Online Coordination Game! The Academy is full of Paths and Playbooks to help you find your way and level up in MetaGame & life."
         url="https://metagame.wtf/academy"
       />
@@ -64,7 +64,7 @@ const AcademyPage: React.FC = () => {
             textAlign="center"
             w={{ base: 'full', xl: ' full' }}
           >
-            The Academy
+            dAcademy
           </Heading>
           <Text
             fontSize={{ base: 'md', '2xl': 'xl' }}


### PR DESCRIPTION
Changed "Academy" and "The Academy" to dAcademy per recent branding shill changes.  Did not change url, to avoid any link conflicts in other places.
